### PR TITLE
Add continuous profiling to command control logic

### DIFF
--- a/scripts/setup/postgres/gprofiler_recreate.sql
+++ b/scripts/setup/postgres/gprofiler_recreate.sql
@@ -245,8 +245,8 @@ CREATE TABLE MinesweeperFrames (
 
 -- Additional Types for Profiling System
 CREATE TYPE ProfilingMode AS ENUM ('cpu', 'allocation', 'none');
-CREATE TYPE ProfilingRequestStatus AS ENUM ('pending', 'assigned', 'completed', 'failed', 'cancelled', 'stopped');
-CREATE TYPE CommandStatus AS ENUM ('pending', 'sent', 'completed', 'failed', 'stopped');
+CREATE TYPE ProfilingRequestStatus AS ENUM ('pending', 'assigned', 'completed', 'failed', 'cancelled');
+CREATE TYPE CommandStatus AS ENUM ('pending', 'sent', 'completed', 'failed');
 CREATE TYPE HostStatus AS ENUM ('active', 'idle', 'error', 'offline');
 
 -- Host Heartbeat Table (simplified)

--- a/src/gprofiler-dev/gprofiler_dev/postgres/db_manager.py
+++ b/src/gprofiler-dev/gprofiler_dev/postgres/db_manager.py
@@ -780,8 +780,7 @@ class DBManager(metaclass=Singleton):
                         ('completed', 0),
                         ('pending', 1),
                         ('sent', 2),
-                        ('stopped', 3),
-                        ('failed', 4)
+                        ('failed', 3)
                 ) AS t(status, status_value)
             ),
             profiling_request_with_command_status AS (
@@ -815,7 +814,7 @@ class DBManager(metaclass=Singleton):
         UPDATE ProfilingRequests
         SET status = fs.status::profilingrequeststatus,
             completed_at = CASE
-                WHEN fs.status IN ('completed', 'failed', 'stopped') THEN CURRENT_TIMESTAMP
+                WHEN fs.status IN ('completed', 'failed') THEN CURRENT_TIMESTAMP
                 ELSE pr.completed_at
             END
         FROM

--- a/src/gprofiler/backend/models/metrics_models.py
+++ b/src/gprofiler/backend/models/metrics_models.py
@@ -197,6 +197,6 @@ class CommandCompletionRequest(BaseModel):
 
     @validator('status')
     def validate_status(cls, v):
-        if v not in ["completed", "failed", "stopped"]:
-            raise ValueError(f"invalid status: {v}. Must be 'completed', 'failed', or 'stopped'.")
+        if v not in ["completed", "failed"]:
+            raise ValueError(f"invalid status: {v}. Must be 'completed' or 'failed'.")
         return v

--- a/src/gprofiler/backend/routers/metrics_routes.py
+++ b/src/gprofiler/backend/routers/metrics_routes.py
@@ -607,7 +607,7 @@ def report_command_completion(completion: CommandCompletionRequest):
         )
         
         # Update the specific profiling execution record for the command_id reported by the CommandCompletionRequest
-        completed_at = datetime.now() if completion.status in ["completed", "failed", "stopped"] else None
+        completed_at = datetime.now() if completion.status in ["completed", "failed"] else None
         db_manager.update_profiling_execution_status(
             command_id=completion.command_id,
             hostname=completion.hostname,


### PR DESCRIPTION
The continuous profiling option was missing from the command control logic.

## Description
 The profiling request should be able to inform if the requested profiling is continuous or not. The command sent to the agent via heartbeat system should inform that as well.

## Related Issue
N/A

## Motivation and Context
Refer to description.

## How Has This Been Tested?
The tests bellow were performed locally, running the backend as a local container:
* Should be able to register a continuous profiling request;
* The profiling request should be converted in a continuous profiling command;
* The heartbeat system have to trigger the continuous profiling correclty;
* The command completion have to handle correctly the status report received from the agent;
* The profiling requests have to be updated correctly after command completion; 

## Screenshots
N/a

## Checklist:
- [X] I have updated the relevant documentation.
- [X] I have added tests for new logic.
