### PR TITLE
Update UI

### DIFF
--- a/src/gprofiler/backend/models/metrics_models.py
+++ b/src/gprofiler/backend/models/metrics_models.py
@@ -210,3 +210,4 @@ class ProfilingHostStatus(BaseModel):
     pids: str
     command_type: str
     profiling_status: str
+    heartbeat_timestamp: datetime

--- a/src/gprofiler/backend/routers/metrics_routes.py
+++ b/src/gprofiler/backend/routers/metrics_routes.py
@@ -666,6 +666,7 @@ def get_profiling_host_status():
             ip_address=ip_address,
             pids=pids,
             command_type=command_type,
-            profiling_status=profiling_status
+            profiling_status=profiling_status,
+            heartbeat_timestamp=host.get("heartbeat_timestamp")
         ))
     return results

--- a/src/gprofiler/frontend/src/utils/datetimesUtils.js
+++ b/src/gprofiler/frontend/src/utils/datetimesUtils.js
@@ -43,6 +43,7 @@ export const TIME_UNITS = {
 export const TIME_FORMATS = {
     DATETIME_BASIC: `yyyy-MM-dd'T'HH:mm:00`,
     DATETIME_PRINTED: 'dd/MM/yyyy HH:mm',
+    DATETIME_WITH_SECONDS: 'dd/MM/yyyy HH:mm:ss',
     DATE_BASIC: 'dd/MM/yyyy',
     TIME_24H: 'HH:mm',
 };


### PR DESCRIPTION
Removed the rule to limit start/stop at specific moments, now it is possible to start/stop a profile at any time.

Added the last heartbeat timestamp to the UI table. It reflect the time in the users timezone.

## Motivation and Context
User could not start or stop a profile at certain moments and need to do this operations at any time.
User could not know the last time his host have done a heartbeat.

## How Has This Been Tested?
Open the UI and select a service/host, both start/stop buttons should be able to click.
Observe the new column 'last heartbeat' in the table. The time is in users timezone.
