### PR TITLE
Update heartbeat README to reflect current implementation

### DIFF
--- a/heartbeat_doc/README_HEARTBEAT.md
+++ b/heartbeat_doc/README_HEARTBEAT.md
@@ -400,14 +400,14 @@ The agent uses two independent execution slots so that non-overlapping profiler 
 
 ```
 DynamicGProfilerManager
-├── primary: ContinuousProfilerSlot   ← main continuous / single-run profiler
+├── continuous: ContinuousProfilerSlot   ← main continuous / single-run profiler
 ├── adhoc:   AdhocProfilerSlot        ← parallel ad-hoc profiler
 └── command_manager: CommandManager   ← priority queue (stop > adhoc > continuous)
 ```
 
 #### ContinuousProfilerSlot
 
-Handles commands where `combined_config.continuous=true` or single-run commands sent to the primary slot. Can be paused (preempted) when a new higher-priority command arrives, and will resume after the ad-hoc command finishes.
+Handles commands where `combined_config.continuous=true` or single-run commands sent to the continuous slot. Can be paused (preempted) when a new higher-priority command arrives, and will resume after the ad-hoc command finishes.
 
 #### AdhocProfilerSlot
 

--- a/heartbeat_doc/README_HEARTBEAT.md
+++ b/heartbeat_doc/README_HEARTBEAT.md
@@ -10,50 +10,155 @@ The heartbeat system enables remote control of gProfiler agents through a simple
 2. **Backend responds with profiling commands** (start/stop) when available
 3. **Agents execute commands with built-in idempotency** to prevent duplicate execution
 4. **Commands are tracked and logged** for audit and debugging
+5. **Agents report hardware performance-counter (PMU) capabilities** so the backend can validate event-level profiling requests before dispatch
 
 ## Architecture
 
 ```
-┌─────────────────┐    heartbeat     ┌──────────────────────┐
-│   gProfiler     │ ──────────────► │  Performance Studio  │
-│    Agent        │                 │      Backend         │
-│                 │ ◄────────────── │                      │
-└─────────────────┘   commands      └──────────────────────┘
-        │                                       │
-        │                                       │
-        ▼                                       ▼
-┌─────────────────┐                 ┌──────────────────────┐
-│  Profile Data   │                 │   PostgreSQL DB      │
-│  (S3/Local)     │                 │   - Host Heartbeats  │
-└─────────────────┘                 │   - Profiling Cmds   │
-                                    └──────────────────────┘
+┌─────────────────────────────┐
+│   gProfiler Agent           │
+│                             │
+│  ┌───────────────────────┐  │
+│  │ ContinuousProfilerSlot│  │    heartbeat (POST /api/metrics/heartbeat)
+│  └───────────────────────┘  │ ──────────────────────────────────────────►
+│  ┌───────────────────────┐  │                                            │
+│  │  AdhocProfilerSlot    │  │ ◄──────────────────────────────────────── │
+│  └───────────────────────┘  │    commands + combined_config              │
+│  ┌───────────────────────┐  │                                            │
+│  │   CommandManager      │  │                               ┌────────────┴─────────────┐
+│  │ (priority queue)      │  │                               │  Performance Studio      │
+│  └───────────────────────┘  │                               │      Backend (FastAPI)   │
+└─────────────────────────────┘                               │                          │
+             │                                                │  - PMU event validation  │
+             │ profile data                                   │  - Slack notifications   │
+             ▼                                                │  - Capacity enforcement  │
+┌─────────────────┐                                          └────────────┬─────────────┘
+│  Profile Data   │                                                       │
+│  (S3/Local)     │                                                       │
+└─────────────────┘                                          ┌────────────▼─────────────┐
+                                                             │   PostgreSQL DB           │
+                                                             │   - HostHeartbeats        │
+                                                             │   - ProfilingRequests     │
+                                                             │   - ProfilingCommands     │
+                                                             │   - ProfilingExecutions   │
+                                                             └──────────────────────────┘
 ```
 
 ## Database Schema
 
-### Core Tables
+### ENUMs
 
-1. **HostHeartbeats** - Track agent status and last seen information
-2. **ProfilingRequests** - Store profiling requests from API calls
-3. **ProfilingCommands** - Commands sent to agents (merged from multiple requests)
-4. **ProfilingExecutions** - Execution history for audit trail
+```sql
+ProfilingMode          = ('cpu', 'allocation', 'none')
+ProfilingRequestStatus = ('pending', 'assigned', 'completed', 'failed', 'cancelled')
+CommandStatus          = ('pending', 'sent', 'completed', 'failed')
+HostStatus             = ('active', 'idle', 'error', 'offline')
+```
 
-### Key Features
-- **Simple DDL** with essential indexes only
-- **No stored procedures** - all logic in application code
-- **No triggers** - timestamps handled by application
-- **Consistent naming** with `idx_` prefix for all indexes
+### `HostHeartbeats`
+
+Tracks agent status and last-seen information. Upserted on `(hostname, service_name)` at every heartbeat.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `bigserial PK` | |
+| `hostname` | `text NOT NULL` | |
+| `ip_address` | `inet NOT NULL` | |
+| `service_name` | `text NOT NULL` | |
+| `last_command_id` | `uuid NULL` | Last command acknowledged by the agent |
+| `received_command_ids` | `uuid[] NULL` | All command IDs the agent has received |
+| `executed_command_ids` | `uuid[] NULL` | All command IDs the agent has executed |
+| `status` | `HostStatus DEFAULT 'active'` | |
+| `heartbeat_timestamp` | `timestamp` | Set by server on upsert |
+| `supported_perf_events` | `text[] NULL` | PMU events reported by the agent; used for bulk request validation |
+| `created_at` / `updated_at` | `timestamp` | |
+
+Indexes: `hostname`, `service_name`, `status`, `heartbeat_timestamp`.
+
+### `ProfilingRequests`
+
+One row per API-level profiling request. Multiple requests for the same host are merged into a single `ProfilingCommands` row.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `bigserial PK` | |
+| `request_id` | `uuid NOT NULL UNIQUE` | |
+| `service_name` | `text NOT NULL` | |
+| `request_type` | `text` | `'start'` or `'stop'` |
+| `continuous` | `boolean DEFAULT false` | Whether the profiler should run in continuous mode |
+| `duration` | `integer DEFAULT 60` | Seconds |
+| `frequency` | `integer DEFAULT 11` | Hz |
+| `profiling_mode` | `ProfilingMode DEFAULT 'cpu'` | |
+| `target_hostnames` | `text[] NOT NULL` | |
+| `pids` | `integer[] NULL` | **Deprecated** — always `NULL`; per-host PIDs are stored in the backend process memory (`DBManager.request_host_pid_mappings`) and lost on restart |
+| `stop_level` | `text DEFAULT 'process'` | `'process'` or `'host'` |
+| `additional_args` | `jsonb NULL` | Merged flat into `combined_config` |
+| `status` | `ProfilingRequestStatus DEFAULT 'pending'` | |
+| `estimated_completion_time` | `timestamp NULL` | |
+| `created_at` / `updated_at` | `timestamp` | |
+
+### `ProfilingCommands`
+
+One active command per `(hostname, service_name)` pair. When a new request arrives for a host that already has a `pending` command, the configs are **merged** (max duration, max frequency, union of PIDs, OR of `continuous`) rather than replaced.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `bigserial PK` | |
+| `command_id` | `uuid NOT NULL` | |
+| `hostname` | `text NOT NULL` | |
+| `service_name` | `text NOT NULL` | |
+| `command_type` | `text` | `'start'` or `'stop'` |
+| `request_ids` | `uuid[] NOT NULL` | All request UUIDs merged into this command |
+| `combined_config` | `jsonb NULL` | Merged configuration delivered to the agent |
+| `status` | `CommandStatus DEFAULT 'pending'` | `'pending'` → `'sent'` at heartbeat; `'completed'`/`'failed'` at completion |
+| `sent_at` | `timestamp NULL` | Set when delivered via heartbeat response |
+| `completed_at` | `timestamp NULL` | |
+| `execution_time` | `integer NULL` | Seconds, as reported by the agent |
+| `error_message` | `text NULL` | |
+| `results_path` | `text NULL` | |
+
+Unique constraint: `(hostname, service_name)` — one active command per host/service pair.
+
+### `ProfilingExecutions`
+
+Audit table. One row is inserted (with `status='assigned'`) when the command is delivered to the agent at heartbeat time — not at completion.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `bigserial PK` | |
+| `command_id` | `uuid NOT NULL` | |
+| `hostname` | `text NOT NULL` | |
+| `profiling_request_id` | `uuid FK → ProfilingRequests` | |
+| `status` | `ProfilingRequestStatus DEFAULT 'pending'` | |
+| `started_at` / `completed_at` | `timestamp NULL` | |
+| `execution_time` | `integer NULL` | |
+| `error_message` | `text NULL` | |
+| `results_path` | `text NULL` | |
 
 ## API Endpoints
 
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/api/metrics/profile_request` | Create a profiling request for one or more hosts |
+| `POST` | `/api/metrics/profile_request/bulk` | Create multiple profiling requests atomically |
+| `POST` | `/api/metrics/heartbeat` | Agent heartbeat — returns pending commands |
+| `POST` | `/api/metrics/command_completion` | Agent reports command execution result |
+| `GET` | `/api/metrics/profiling/host_status` | Dashboard: per-host profiling status |
+
 ### 1. Create Profiling Request
+
 ```http
 POST /api/metrics/profile_request
 Content-Type: application/json
+```
 
+**Request:**
+
+```json
 {
   "service_name": "my-service",
   "request_type": "start",
+  "continuous": false,
   "duration": 60,
   "frequency": 11,
   "profiling_mode": "cpu",
@@ -62,101 +167,332 @@ Content-Type: application/json
     "host2": null
   },
   "stop_level": "process",
-  "additional_args": {}
+  "additional_args": {},
+  "dry_run": false
 }
 ```
 
+| Field | Required | Default | Notes |
+|---|---|---|---|
+| `service_name` | yes | — | |
+| `request_type` | yes | — | `"start"` or `"stop"` |
+| `target_hosts` | yes | — | Dict of `hostname → [pids]` or `hostname → null` |
+| `continuous` | no | `false` | Keep profiling running until an explicit stop |
+| `duration` | no | `60` | Seconds; must be > 0 |
+| `frequency` | no | `11` | Hz; must be > 0 |
+| `profiling_mode` | no | `"cpu"` | `"cpu"`, `"allocation"`, or `"none"` |
+| `stop_level` | no | `"process"` | `"process"` requires at least one host to have PIDs; `"host"` forbids PIDs |
+| `additional_args` | no | `{}` | Merged flat into `combined_config` |
+| `dry_run` | no | `false` | Validates and returns a response without writing to the database |
+
 **Response:**
+
 ```json
 {
   "success": true,
-  "message": "Start profiling request submitted successfully",
-  "request_id": "uuid",
-  "command_id": "uuid",
-  "estimated_completion_time": "2025-01-15T10:30:00Z"
+  "message": "Start profiling request submitted successfully for service 'my-service' across 2 hosts",
+  "request_id": "req-uuid",
+  "command_ids": ["cmd-uuid-host1", "cmd-uuid-host2"],
+  "estimated_completion_time": "2026-03-04T10:30:00Z"
 }
 ```
 
-### 2. Agent Heartbeat
+> **Note:** `command_ids` is a list — one UUID per target host. For `"stop"` requests `estimated_completion_time` is `null`. For `dry_run=true`, `request_id` is `null` and `command_ids` is empty.
+
+### 2. Bulk Create Profiling Requests
+
+Atomically submit multiple profiling requests. Capacity validation (`MAX_PROFILING_REQUEST_HOSTS`, `MAX_SIMULTANEOUS_PROFILING_HOSTS`) runs once across the entire batch before any individual request is processed.
+
+```http
+POST /api/metrics/profile_request/bulk
+Content-Type: application/json
+```
+
+**Request:**
+
+```json
+{
+  "requests": [
+    { "service_name": "svc-a", "request_type": "start", "target_hosts": {"host1": null} },
+    { "service_name": "svc-b", "request_type": "start", "target_hosts": {"host2": [1234]} }
+  ],
+  "dry_run": false
+}
+```
+
+`dry_run` at the bulk level overrides every individual request's `dry_run`.
+
+**Response:**
+
+```json
+{
+  "total_submitted": 2,
+  "successful_count": 2,
+  "failed_count": 0,
+  "results": [
+    {
+      "index": 0,
+      "service_name": "svc-a",
+      "success": true,
+      "response": { "success": true, "request_id": "...", "command_ids": ["..."] },
+      "error": null
+    }
+  ]
+}
+```
+
+### 3. Agent Heartbeat
+
 ```http
 POST /api/metrics/heartbeat
 Content-Type: application/json
+```
 
+**Request:**
+
+```json
 {
   "hostname": "host1",
   "ip_address": "10.0.1.100",
   "service_name": "my-service",
   "last_command_id": "previous-command-uuid",
-  "status": "active"
+  "received_command_ids": ["uuid-a", "uuid-b"],
+  "executed_command_ids": ["uuid-a"],
+  "status": "active",
+  "timestamp": "2026-03-04T10:00:00Z",
+  "perf_supported_events": ["cpu-cycles", "cache-misses", "instructions"]
 }
 ```
 
-**Response (with command):**
+| Field | Required | Notes |
+|---|---|---|
+| `hostname` | yes | |
+| `ip_address` | yes | |
+| `service_name` | yes | |
+| `last_command_id` | no | Last command ID the agent acknowledged |
+| `received_command_ids` | no | All command IDs the agent has received (for fine-grained tracking) |
+| `executed_command_ids` | no | All command IDs the agent has started executing |
+| `status` | no | `"active"` (default), `"idle"`, or `"error"` |
+| `timestamp` | no | ISO 8601; set by the server if absent |
+| `perf_supported_events` | no | PMU events available on this host; used for bulk request validation |
+
+**Response — no pending command:**
+
+```json
+{
+  "success": true,
+  "message": "Heartbeat received. No profiling commands.",
+  "profiling_command": null,
+  "command_id": null
+}
+```
+
+**Response — command available:**
+
 ```json
 {
   "success": true,
   "message": "Heartbeat received. New profiling command available.",
-  "command_id": "new-command-uuid",
+  "command_id": "cmd-uuid",
   "profiling_command": {
     "command_type": "start",
     "combined_config": {
+      "continuous": false,
       "duration": 60,
       "frequency": 11,
       "profiling_mode": "cpu",
-      "pids": "1234,5678"
+      "pids": [1234, 5678],
+      "stop_level": "process"
     }
   }
 }
 ```
 
-### 3. Command Completion
+> **Note:** `combined_config.pids` is a JSON integer array `[1234, 5678]`, not a comma-delimited string.
+
+The heartbeat endpoint always returns HTTP 200. If an internal error occurs while looking up commands, the response body will contain `success: true` with an error message — it never returns 5xx from this path.
+
+### 4. Command Completion
+
 ```http
 POST /api/metrics/command_completion
 Content-Type: application/json
+```
 
+**Request:**
+
+```json
 {
-  "command_id": "command-uuid",
+  "command_id": "cmd-uuid",
   "hostname": "host1",
   "status": "completed",
   "execution_time": 65,
+  "error_message": null,
   "results_path": "/path/to/results"
 }
 ```
 
+| Field | Required | Notes |
+|---|---|---|
+| `command_id` | yes | |
+| `hostname` | yes | |
+| `status` | yes | `"completed"` or `"failed"` |
+| `execution_time` | no | Seconds |
+| `error_message` | no | Populated on `"failed"` status |
+| `results_path` | no | |
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "message": "Command completion recorded for cmd-uuid"
+}
+```
+
+Or, if the command is not found / not in `'assigned'` state for this host:
+
+```json
+{
+  "success": false,
+  "message": "Command cmd-uuid not found for host host1"
+}
+```
+
+> **Note:** If the agent reports a `command_id` that no longer matches the host's current active command (i.e., a stale completion), `ProfilingRequests` status is not updated — only completions for the current active command trigger request status propagation.
+
+### 5. Host Status Dashboard
+
+```http
+GET /api/metrics/profiling/host_status
+```
+
+Query parameters (all optional, repeatable): `service_name[]`, `hostname[]`, `ip_address[]`, `profiling_status[]`, `command_type[]`, `pids[]`, `exact_match`.
+
+**Response:**
+
+```json
+{
+  "hosts": [
+    {
+      "id": 1,
+      "service_name": "my-service",
+      "hostname": "host1",
+      "ip_address": "10.0.1.100",
+      "pids": [1234],
+      "command_type": "start",
+      "profiling_status": "sent",
+      "heartbeat_timestamp": "2026-03-04T10:00:00Z"
+    }
+  ],
+  "active_count": 1,
+  "total_count": 5
+}
+```
+
+`profiling_status` reflects the current `ProfilingCommands.status`. If no command exists for a host, it reports `"stopped"`.
+
 ## Agent Integration
 
-### Heartbeat Configuration
+### Two-Slot Architecture
+
+The agent uses two independent execution slots so that non-overlapping profiler types can run in parallel:
+
+```
+DynamicGProfilerManager
+├── primary: ContinuousProfilerSlot   ← main continuous / single-run profiler
+├── adhoc:   AdhocProfilerSlot        ← parallel ad-hoc profiler
+└── command_manager: CommandManager   ← priority queue (stop > adhoc > continuous)
+```
+
+#### ContinuousProfilerSlot
+
+Handles commands where `combined_config.continuous=true` or single-run commands sent to the primary slot. Can be paused (preempted) when a new higher-priority command arrives, and will resume after the ad-hoc command finishes.
+
+#### AdhocProfilerSlot
+
+Handles ad-hoc (non-continuous) commands. Can run **in parallel** with `ContinuousProfilerSlot` if the two commands profile different runtime types (no overlapping profiler types). If there is overlap, the continuous command is paused (time-sliced) until the ad-hoc command completes.
+
+Profiler type overlap is detected from `profiler_configs` keys using this mapping:
+
+| Config Key | Canonical Type |
+|---|---|
+| `perf` | `perf` |
+| `async_profiler` | `java` |
+| `pyperf` / `pyspy` | `python` |
+| `phpspy` | `php` |
+| `rbspy` | `ruby` |
+| `dotnet_trace` | `dotnet` |
+| `nodejs_perf` | `nodejs` |
+
+#### CommandManager Priority Queue
+
+Three queues with fixed capacities. `get_next_command()` peeks (non-destructively) in priority order:
+
+1. **Stop queue** (max 1) — processed immediately; clears all other queues
+2. **Ad-hoc queue** (max 10)
+3. **Continuous queue** (max 1) — if a second continuous command arrives, earlier pending continuous commands are silently discarded
+
+Commands are dequeued by the profiler thread's `finally` block after the run completes. Paused continuous commands are deliberately kept in the queue so they can be resumed by the next heartbeat tick.
+
+### Heartbeat Loop
+
+Every `--heartbeat-interval` seconds the agent:
+
+1. Sends `POST /api/metrics/heartbeat` with current state
+2. If a command is returned, enqueues it (idempotency check against `received_command_ids`)
+3. Cleans up any completed ad-hoc profiler threads
+4. Peeks at the next command and dispatches it if conditions are met
+5. Sleeps until next tick (interruptible)
+
+Idempotency is enforced by two sets (`received_command_ids`, `executed_command_ids`) capped at 1000 entries each, trimmed by keeping the most recent entries.
+
+### `send_command_completion` Timing
+
+`POST /api/metrics/command_completion` is called when a profiler is **started** (not when it finishes). Consequently, `execution_time` is always sent as `0` from the agent. The actual duration is not reported back to the backend.
+
+### Startup Command
+
 ```bash
 python3 gprofiler/main.py \
   --enable-heartbeat-server \
+  --upload-results \
   --api-server "https://perf-studio.example.com" \
-  --heartbeat-interval 30 \
   --service-name "my-service" \
-  --token "api-token"
+  --token "api-token" \
+  --heartbeat-interval 30
 ```
 
-### Heartbeat Flow
-1. **Agent sends heartbeat** every 30 seconds (configurable)
-2. **Backend checks for pending commands** for this hostname/service
-3. **If command available**, backend responds with command details
-4. **Agent executes command** and reports completion
-5. **Idempotency ensured** by tracking `last_command_id`
+### CLI Reference
 
-## Command Types
+#### Heartbeat Flags (the `--enable-heartbeat-server` group requires all three starred flags)
 
-### START Commands
-- Create new profiling sessions
-- Merge multiple requests for same host
-- Include combined configuration (duration, frequency, PIDs)
+| Flag | Default | Notes |
+|---|---|---|
+| `--enable-heartbeat-server` | off | Activates heartbeat mode; mutually exclusive with normal profiling |
+| `--upload-results` / `-u` | off | ★ Required with `--enable-heartbeat-server` |
+| `--token TOKEN` | — | ★ Required; sent as `Authorization: Bearer` on profile uploads |
+| `--service-name NAME` | — | ★ Required |
+| `--api-server URL` | (default address) | Backend base URL; `--server` is a deprecated alias |
+| `--heartbeat-interval SECONDS` | `30` | Sleep between heartbeat POST requests |
+| `--no-verify` | — | Skip TLS server certificate verification |
 
-### STOP Commands
-- **Process-level**: Stop specific PIDs
-- **Host-level**: Stop entire profiling session
-- Automatic conversion when only one PID remains
+> **Note:** `--heartbeat-file PATH` is an **unrelated** feature — it touches a filesystem timestamp inside the normal snapshot loop as a liveness probe. It does not interact with the heartbeat protocol described here.
+
+#### mTLS Flags
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--tls-client-cert PATH` | — | PEM client certificate |
+| `--tls-client-key PATH` | — | PEM client private key; both cert and key must be provided for mTLS to activate |
+| `--tls-ca-bundle PATH` | — | PEM CA bundle; overrides system CA store |
+| `--tls-cert-refresh-enabled` | off | Enables background cert rotation thread |
+| `--tls-cert-refresh-interval SECONDS` | `21600` | Cert refresh interval (default: 6 hours) |
 
 ## Data Flow Example
 
 ### 1. Create Profiling Request
+
 ```bash
 curl -X POST http://localhost:8000/api/metrics/profile_request \
   -H "Content-Type: application/json" \
@@ -164,25 +500,29 @@ curl -X POST http://localhost:8000/api/metrics/profile_request \
     "service_name": "web-service",
     "request_type": "start",
     "duration": 120,
-    "target_hostnames": ["web-01", "web-02"],
+    "target_hosts": {"web-01": null, "web-02": null},
     "profiling_mode": "cpu"
   }'
 ```
 
-### 2. Agent Heartbeat
+### 2. Agent Heartbeat (sent automatically by the agent)
+
 ```bash
-# Agent automatically sends:
 curl -X POST http://localhost:8000/api/metrics/heartbeat \
   -H "Content-Type: application/json" \
   -d '{
     "hostname": "web-01",
     "ip_address": "10.0.1.10",
     "service_name": "web-service",
-    "status": "active"
+    "status": "active",
+    "received_command_ids": [],
+    "executed_command_ids": [],
+    "perf_supported_events": ["cpu-cycles", "instructions"]
   }'
 ```
 
 ### 3. Agent Receives Command
+
 ```json
 {
   "success": true,
@@ -192,13 +532,15 @@ curl -X POST http://localhost:8000/api/metrics/heartbeat \
     "combined_config": {
       "duration": 120,
       "frequency": 11,
-      "profiling_mode": "cpu"
+      "profiling_mode": "cpu",
+      "continuous": false
     }
   }
 }
 ```
 
 ### 4. Agent Reports Completion
+
 ```bash
 curl -X POST http://localhost:8000/api/metrics/command_completion \
   -H "Content-Type: application/json" \
@@ -206,15 +548,79 @@ curl -X POST http://localhost:8000/api/metrics/command_completion \
     "command_id": "cmd-12345",
     "hostname": "web-01",
     "status": "completed",
-    "execution_time": 122
+    "execution_time": 0
   }'
+```
+
+## Configuration
+
+### Backend Environment Variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `MAX_PROFILING_REQUEST_HOSTS` | `20` | Max number of target hosts per single profiling request |
+| `MAX_SIMULTANEOUS_PROFILING_HOSTS` | `10` (%) | Max percentage of the total fleet that can be profiled simultaneously; enforced at bulk-request level |
+| `ACTIVE_HOST_HEARTBEAT_MAX_DELTA_HOURS` | `24` | Hours of inactivity before a host is excluded from capacity calculations |
+| `SLACK_BOT_TOKEN` | — | If set, Slack notifications are sent on every profiling request |
+| `SLACK_CHANNELS` | `#gprofiler-notifications` | Comma-separated Slack channels for notifications |
+| `METRICS_ENABLED` | `false` | Enable internal SLI metric publishing via ZMQ |
+| `METRICS_AGENT_URL` | `tcp://localhost:18126` | ZMQ metrics agent address |
+| `METRICS_SERVICE_NAME` | `gprofiler-webapp` | Service label for SLI metrics |
+
+### Agent Configuration Summary
+
+See the [CLI Reference](#cli-reference) above. The minimum viable invocation for heartbeat mode:
+
+```bash
+python3 gprofiler/main.py \
+  --enable-heartbeat-server \
+  --upload-results \
+  --token "api-token" \
+  --service-name "my-service" \
+  --api-server "https://perf-studio.example.com"
+```
+
+## Monitoring and Debugging
+
+### Database Queries
+
+```sql
+-- Check active hosts (default: hosts seen within last 24 hours)
+SELECT hostname, service_name, status, heartbeat_timestamp
+FROM HostHeartbeats
+WHERE heartbeat_timestamp > NOW() - INTERVAL '24 hours'
+ORDER BY heartbeat_timestamp DESC;
+
+-- Check pending commands
+SELECT hostname, service_name, command_type, status, created_at
+FROM ProfilingCommands
+WHERE status = 'pending';
+
+-- Check command execution history
+SELECT pe.hostname, pr.request_type, pe.status, pe.execution_time, pe.error_message
+FROM ProfilingExecutions pe
+JOIN ProfilingRequests pr ON pe.profiling_request_id = pr.request_id
+ORDER BY pe.created_at DESC;
+```
+
+### Log Monitoring
+
+```bash
+# Backend logs
+tail -f /var/log/gprofiler-studio/backend.log | grep -E "(heartbeat|command)"
+
+# Agent logs
+tail -f /tmp/gprofiler-heartbeat.log | grep -E "(heartbeat|command)"
 ```
 
 ## Testing
 
-### 1. Test Heartbeat System
+### Heartbeat System Tests
+
+Test scripts are located in `heartbeat_doc/`:
+
 ```bash
-cd gprofiler-performance-studio
+cd gprofiler-performance-studio/heartbeat_doc
 python3 test_heartbeat_system.py
 ```
 
@@ -224,73 +630,11 @@ This script:
 - Verifies command delivery and idempotency
 - Tests both start and stop commands
 
-### 2. Run Test Agent
+### Run Test Agent
+
 ```bash
+cd gprofiler-performance-studio/heartbeat_doc
 python3 run_heartbeat_agent.py
-```
-
-This script:
-- Starts a real gProfiler agent in heartbeat mode
-- Connects to the Performance Studio backend
-- Receives and executes actual profiling commands
-
-## Configuration
-
-### Backend Configuration
-```yaml
-# Backend settings
-database:
-  host: localhost
-  port: 5432
-  database: gprofiler
-  
-heartbeat:
-  max_age_minutes: 10  # Consider hosts offline after 10 minutes
-  cleanup_interval: 300  # Clean up old records every 5 minutes
-```
-
-### Agent Configuration
-```bash
-# Required parameters
---enable-heartbeat-server          # Enable heartbeat mode
---api-server URL                   # Performance Studio backend URL
---service-name NAME                # Service identifier
---heartbeat-interval SECONDS       # Heartbeat frequency (default: 30)
-
-# Optional parameters
---token TOKEN                      # Authentication token
---server-host URL                  # Profile upload server (can be same as api-server)
---no-verify                        # Skip SSL verification (testing only)
-```
-
-## Monitoring and Debugging
-
-### Database Queries
-```sql
--- Check active hosts
-SELECT hostname, service_name, status, heartbeat_timestamp 
-FROM HostHeartbeats 
-WHERE status = 'active' AND heartbeat_timestamp > NOW() - INTERVAL '10 minutes';
-
--- Check pending commands
-SELECT hostname, service_name, command_type, status, created_at 
-FROM ProfilingCommands 
-WHERE status = 'pending';
-
--- Check command execution history
-SELECT pe.hostname, pr.request_type, pe.status, pe.execution_time
-FROM ProfilingExecutions pe
-JOIN ProfilingRequests pr ON pe.profiling_request_id = pr.ID
-ORDER BY pe.created_at DESC;
-```
-
-### Log Monitoring
-```bash
-# Backend logs
-tail -f /var/log/gprofiler-studio/backend.log | grep -E "(heartbeat|command)"
-
-# Agent logs  
-tail -f /tmp/gprofiler-heartbeat.log | grep -E "(heartbeat|command)"
 ```
 
 ## Troubleshooting
@@ -298,48 +642,49 @@ tail -f /tmp/gprofiler-heartbeat.log | grep -E "(heartbeat|command)"
 ### Common Issues
 
 1. **Agents not receiving commands**
-   - Check heartbeat connectivity to backend
-   - Verify service_name matches between request and agent
-   - Check agent authentication (token)
+   - Verify `service_name` matches exactly between the profiling request and the agent's `--service-name` flag
+   - Confirm the agent's hostname appears in `target_hosts` in the profiling request
+   - Check that the agent's heartbeat is reaching the backend (use the debug `curl` below)
 
 2. **Commands executing multiple times**
-   - Verify agent is tracking `last_command_id` correctly
-   - Check for agent restarts that reset command tracking
+   - The agent tracks `received_command_ids` and `executed_command_ids` across heartbeats; a process restart clears these in-memory sets, which can allow re-execution of previously seen commands
+   - Check for rapid agent restarts
 
-3. **Commands not being created**
-   - Verify `target_hostnames` includes the agent's hostname
-   - Check database constraints and foreign key relationships
+3. **Commands not appearing for the agent**
+   - The command `status` may already be `'sent'` or `'completed'` from a previous heartbeat; only `'pending'` commands are dispatched
+   - Ensure no stale `ProfilingCommands` row with `(hostname, service_name)` unique constraint is blocking new commands
+
+4. **Bulk request rejected**
+   - Check `MAX_PROFILING_REQUEST_HOSTS` (default 20) and `MAX_SIMULTANEOUS_PROFILING_HOSTS` (default 10%) limits
+   - The bulk endpoint validates capacity across all requests in the batch before processing any of them
 
 ### Debug Commands
+
 ```bash
 # Test backend connectivity
-curl -v http://localhost:8000/api/metrics/heartbeat \
+curl -s -X POST http://localhost:8000/api/metrics/heartbeat \
   -H "Content-Type: application/json" \
-  -d '{"hostname":"test","ip_address":"127.0.0.1","service_name":"test","status":"active"}'
+  -d '{"hostname":"test","ip_address":"127.0.0.1","service_name":"test","status":"active"}' | python3 -m json.tool
 
 # Check database state
-psql -d gprofiler -c "SELECT * FROM HostHeartbeats ORDER BY heartbeat_timestamp DESC LIMIT 5;"
+psql -d gprofiler -c "SELECT hostname, service_name, status, heartbeat_timestamp FROM HostHeartbeats ORDER BY heartbeat_timestamp DESC LIMIT 10;"
+
+# Check pending and sent commands
+psql -d gprofiler -c "SELECT hostname, service_name, command_type, status, created_at, sent_at FROM ProfilingCommands WHERE status IN ('pending','sent') ORDER BY created_at DESC;"
 ```
 
 ## Security Considerations
 
-1. **Authentication**: Use API tokens for agent authentication
-2. **Network**: Secure communication with HTTPS/TLS
-3. **Authorization**: Validate service permissions before creating commands
-4. **Rate Limiting**: Implement rate limits on heartbeat endpoints
-5. **Input Validation**: Sanitize all input parameters
+1. **Authentication on heartbeat endpoints**: The `/api/metrics/heartbeat`, `/api/metrics/profile_request`, and `/api/metrics/command_completion` endpoints do **not** currently enforce authentication. The agent's `--token` flag is used for profile-upload API calls, not for the heartbeat protocol endpoints.
+2. **Network**: Secure all communication with HTTPS. Use `--tls-client-cert` / `--tls-client-key` for mTLS where required.
+3. **mTLS cert rotation**: Enable `--tls-cert-refresh-enabled` with an appropriate `--tls-cert-refresh-interval` to periodically rotate the client certificate without restarting the agent.
+4. **TLS verification**: Never use `--no-verify` in production.
+5. **Input Validation**: All request payloads are validated via Pydantic models; invalid inputs return HTTP 422.
 
 ## Performance Considerations
 
-1. **Database Indexes**: Essential indexes are created for all lookup patterns
-2. **Heartbeat Frequency**: Balance between responsiveness and load (default: 30s)
-3. **Command Cleanup**: Implement periodic cleanup of old commands/executions
-4. **Connection Pooling**: Use connection pooling for database access
-
-## Future Enhancements
-
-1. **Agent Discovery**: Automatic service registration
-2. **Command Queuing**: Support for command queues per host
-3. **Conditional Commands**: Commands based on host metrics or state
-4. **Command Templates**: Predefined command templates for common scenarios
-5. **Real-time Dashboard**: Web UI for monitoring active agents and commands
+1. **Database Indexes**: All high-frequency lookup patterns (`hostname`, `service_name`, `status`, `heartbeat_timestamp`) are indexed.
+2. **Heartbeat Frequency**: Default 30 s balances responsiveness against backend load. Reduce `--heartbeat-interval` for faster command pickup.
+3. **Command Merging**: Multiple profiling requests for the same host are merged into a single `ProfilingCommands` row (max duration, max frequency, union of PIDs). This avoids parallel command dispatch to the same host.
+4. **Connection Pooling**: Use connection pooling (e.g., PgBouncer) for database access at scale.
+5. **Capacity Limits**: `MAX_SIMULTANEOUS_PROFILING_HOSTS` prevents fleet-wide profiling storms; tune this percentage for your environment.


### PR DESCRIPTION
# Update heartbeat README to reflect current implementation

## What

Rewrote `heartbeat_doc/README_HEARTBEAT.md` to reflect the current state of both
the Performance Studio backend and the gProfiler agent.

## Why

The document was drafted several months ago and had drifted from the actual
implementation in a number of places, making it unreliable as a reference.

## Changes

**API contract corrections**
- `POST /api/metrics/profile_request`: fixed response field `command_id` (single
  string) → `command_ids` (array of UUIDs, one per target host); added `continuous`,
  `dry_run`, and `stop_level` request fields with their validation rules.
- `POST /api/metrics/heartbeat`: added `received_command_ids`, `executed_command_ids`,
  and `perf_supported_events` request fields; fixed `combined_config.pids` type from
  comma-delimited string to JSON integer array; documented the no-command response shape.
- `POST /api/metrics/command_completion`: added `error_message` field; documented
  the actual response body (`{"success": bool, "message": str}`).

**New endpoints documented**
- `POST /api/metrics/profile_request/bulk` — atomic bulk submission with capacity
  validation and partial-failure reporting.
- `GET /api/metrics/profiling/host_status` — per-host profiling status dashboard.

**Database schema**
- Replaced the brief bullet-list summary with column-level tables for all four tables
  plus ENUM definitions.
- `HostHeartbeats`: added `received_command_ids`, `executed_command_ids`,
  `supported_perf_events` columns.
- `ProfilingRequests`: added `continuous`, `stop_level`; noted that `pids` is
  deprecated (always NULL — per-host PIDs are held in process memory only).
- Documented command-merge behavior and the `ProfilingExecutions` insert-on-assign
  lifecycle (rows created at heartbeat dispatch, not at completion).

**Agent integration**
- Documented the two-slot architecture (`ContinuousProfilerSlot` + `AdhocProfilerSlot`)
  and profiler-type overlap detection.
- Documented `CommandManager` priority-queue behavior (stop > adhoc > continuous).
- Added a complete CLI reference table for all heartbeat and mTLS flags.
- Clarified that `--heartbeat-file` is an unrelated liveness feature, not part of
  this protocol.
- Noted that `execution_time` is always sent as `0` (completion is reported at
  profiler start, not at actual finish).

**Configuration**
- Replaced the non-existent YAML config block with the actual backend environment
  variables (`MAX_PROFILING_REQUEST_HOSTS`, `MAX_SIMULTANEOUS_PROFILING_HOSTS`,
  `ACTIVE_HOST_HEARTBEAT_MAX_DELTA_HOURS`, Slack vars, metrics vars).
- Corrected "hosts go offline after 10 minutes" → controlled by
  `ACTIVE_HOST_HEARTBEAT_MAX_DELTA_HOURS` (default: **24 hours**).

**Security**
- Corrected the claim that the heartbeat endpoints use API-token authentication —
  they currently have **no authentication**. The `--token` flag is consumed by the
  profile-upload path only.

## Files changed

| File | Change |
|---|---|
| `heartbeat_doc/README_HEARTBEAT.md` | Rewritten (486 insertions, 141 deletions) |
