### PR TITLE
Profiling Request Modal - Perf Profiler Status Displaying Incorrectly

### DIFF
--- a/src/gprofiler/frontend/src/components/console/ProfilingStatusPage.jsx
+++ b/src/gprofiler/frontend/src/components/console/ProfilingStatusPage.jsx
@@ -712,8 +712,8 @@ const ProfilingStatusPage = () => {
                                         Profiler Settings:
                                     </Typography>
                                     <Typography variant="body2">• Perf (C/C++/Go): {
-                                        profilerConfigs.perf === 'enabled_restricted' ? 'Enabled (Restricted)' :
-                                        profilerConfigs.perf === 'enabled_aggressive' ? 'Enabled (Aggressive)' : 'Disabled'
+                                        profilerConfigs.perf?.mode === 'enabled_restricted' ? 'Enabled (Restricted)' :
+                                        profilerConfigs.perf?.mode === 'enabled_aggressive' ? 'Enabled (Aggressive)' : 'Disabled'
                                     }</Typography>
                                     <Typography variant="body2">• Java Async Profiler: {
                                         profilerConfigs.async_profiler?.enabled 


### PR DESCRIPTION
# Fix: Profiling Request Modal - Perf Profiler Status Displaying Incorrectly

## Summary

Fixes a bug in the Profiling Request confirmation/review modal where the **Perf (C/C++/Go)** profiler status was always displayed as `Disabled`, regardless of what the user had actually selected.

## Problem

In `ProfilingStatusPage.jsx`, the `profilerConfigs.perf` state is initialized as a structured object:

```js
perf: {
    mode: 'enabled_restricted', // 'enabled_restricted', 'enabled_aggressive', 'disabled'
    events: ['cpu-cycles']
}
```

However, the confirmation dialog was comparing it directly against strings:

```jsx
// Before (broken)
profilerConfigs.perf === 'enabled_restricted' ? 'Enabled (Restricted)' :
profilerConfigs.perf === 'enabled_aggressive' ? 'Enabled (Aggressive)' : 'Disabled'
```

Since `profilerConfigs.perf` is an object, the equality checks always evaluated to `false`, and the Perf profiler entry always fell through to `'Disabled'` — even when the user had configured it as enabled.

## Fix

Updated the comparison to correctly access the nested `mode` property using optional chaining:

```jsx
// After (fixed)
profilerConfigs.perf?.mode === 'enabled_restricted' ? 'Enabled (Restricted)' :
profilerConfigs.perf?.mode === 'enabled_aggressive' ? 'Enabled (Aggressive)' : 'Disabled'
```

## Files Changed

- `src/gprofiler/frontend/src/components/console/ProfilingStatusPage.jsx`

## Testing

1. Navigate to the Profiling Status page.
2. Select one or more hosts and click **Start Profiling**.
3. In the confirmation modal, verify that the **Perf (C/C++/Go)** field under *Profiler Settings* now correctly reflects the mode configured in the UI (e.g., `Enabled (Restricted)`, `Enabled (Aggressive)`, or `Disabled`).

## Notes

- No functional/behavioral change to how profiling requests are built or dispatched — this is a display-only fix in the confirmation dialog.
- All other profiler config fields (`async_profiler`, `pyperf`, `pyspy`, `rbspy`, `phpspy`, `dotnet_trace`, `nodejs_perf`) were already reading their values correctly and are unaffected.
