### PR TITLE
Adhoc Flamegraphs: Mark S3-Removed Files in UI

### DIFF
--- a/src/gprofiler-dev/gprofiler_dev/s3_profile_dal.py
+++ b/src/gprofiler-dev/gprofiler_dev/s3_profile_dal.py
@@ -14,9 +14,10 @@
 # limitations under the License.
 #
 import gzip
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from io import BytesIO
-from typing import Callable, Optional, List, Dict
+from typing import Callable, Optional, List, Dict, Set
 
 import boto3
 from botocore.config import Config
@@ -88,6 +89,37 @@ class S3ProfileDal:
 
     def upload_file(self, local_path: str, dest_path: str) -> None:
         self._s3_client.upload_file(local_path, self.bucket_name, dest_path)
+
+    def check_keys_exist(self, keys: List[str]) -> Set[str]:
+        """Check which S3 keys in *keys* actually exist.
+
+        Issues one head_object call per key, all in parallel via a
+        ThreadPoolExecutor, so total latency ≈ one S3 round-trip.
+
+        Returns a set of keys that are present in S3.
+        """
+        if not keys:
+            return set()
+
+        def _head(key: str) -> Optional[str]:
+            try:
+                self._s3_client.head_object(Bucket=self.bucket_name, Key=key)
+                return key
+            except ClientError as e:
+                if e.response.get("Error", {}).get("Code") in ("404", "NoSuchKey"):
+                    return None
+                # Unexpected error – treat as absent but log it
+                self.logger.warning(f"Unexpected S3 error for key {key!r}: {e}")
+                return None
+
+        existing: Set[str] = set()
+        with ThreadPoolExecutor(max_workers=min(len(keys), 32)) as executor:
+            futures = {executor.submit(_head, key): key for key in keys}
+            for future in as_completed(futures):
+                result = future.result()
+                if result is not None:
+                    existing.add(result)
+        return existing
 
     def list_files_with_prefix(self, prefix: str) -> List[Dict]:
         """List files in S3 with the given prefix"""

--- a/src/gprofiler/backend/routers/metrics_routes.py
+++ b/src/gprofiler/backend/routers/metrics_routes.py
@@ -70,6 +70,7 @@ class FlamegraphFile(BaseModel):
     size: Optional[int] = None
     s3_path: str
     perf_events: Optional[List[str]] = None
+    removed: bool = False
 
 
 class FlamegraphContent(BaseModel):
@@ -1007,7 +1008,7 @@ def get_adhoc_flamegraphs(
         for metadata in metadata_list:
             s3_key = metadata["s3_key"]
             filename = s3_key.split('/')[-1]
-            
+
             flamegraph_files.append(FlamegraphFile(
                 filename=filename,
                 timestamp=datetime.fromisoformat(metadata["start_time"]),
@@ -1016,7 +1017,17 @@ def get_adhoc_flamegraphs(
                 s3_path=s3_key,
                 perf_events=metadata.get("perf_events")
             ))
-        
+
+        # Mark entries whose S3 file no longer exists.
+        # All head_object calls are issued in parallel (one thread per key)
+        # so the total latency is ~one S3 round-trip regardless of list size.
+        if flamegraph_files:
+            s3_dal = S3ProfileDal(logger)
+            all_s3_paths = [f.s3_path for f in flamegraph_files]
+            existing_keys = s3_dal.check_keys_exist(all_s3_paths)
+            for f in flamegraph_files:
+                f.removed = f.s3_path not in existing_keys
+
         return flamegraph_files
         
     except Exception as e:

--- a/src/gprofiler/frontend/src/components/profiles/views/adhoc/AdhocProfilingView.jsx
+++ b/src/gprofiler/frontend/src/components/profiles/views/adhoc/AdhocProfilingView.jsx
@@ -15,7 +15,7 @@
  */
 
 import { useContext, useEffect, useState } from 'react';
-import { Box, Typography, Select, MenuItem, FormControl, InputLabel, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, Button, IconButton, Collapse } from '@mui/material';
+import { Box, Typography, Select, MenuItem, FormControl, InputLabel, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, Button, Chip, IconButton, Collapse } from '@mui/material';
 import { SelectorsContext } from '@/states';
 import { FilterTagsContext } from '@/states/filters/FiltersTagsContext';
 import useFetchWithRequest from '@/api/useFetchWithRequest';
@@ -89,6 +89,7 @@ const AdhocProfilingView = () => {
     };
 
     const handleRowClick = (file) => {
+        if (file.removed) return;
         setSelectedFile(file);
     };
 
@@ -131,8 +132,9 @@ const AdhocProfilingView = () => {
                                 onClick={(e) => e.stopPropagation()}
                             >
                                 {filesData.map((file) => (
-                                    <MenuItem key={file.filename} value={file.filename}>
+                                    <MenuItem key={file.filename} value={file.filename} disabled={file.removed}>
                                         {format(new Date(file.timestamp), 'yyyy-MM-dd HH:mm:ss')} - {file.hostname || 'N/A'}
+                                        {file.removed && ' (removed)'}
                                     </MenuItem>
                                 ))}
                             </Select>
@@ -159,26 +161,37 @@ const AdhocProfilingView = () => {
                                     </TableRow>
                                 </TableHead>
                                 <TableBody>
-                                    {filesData.map((file) => (
-                                        <TableRow
-                                            key={file.filename}
-                                            onClick={() => handleRowClick(file)}
-                                            selected={selectedFile?.filename === file.filename}
-                                            sx={{ cursor: 'pointer', '&:hover': { backgroundColor: 'action.hover' } }}
-                                        >
-                                            <TableCell>{format(new Date(file.timestamp), 'yyyy-MM-dd HH:mm:ss')}</TableCell>
-                                            <TableCell>{file.hostname || 'N/A'}</TableCell>
-                                            <TableCell>
-                                                {file.perf_events && file.perf_events.length > 0 
-                                                    ? file.perf_events.join(', ') 
-                                                    : 'N/A'}
-                                            </TableCell>
-                                            <TableCell>{(file.size / 1024).toFixed(2)} KB</TableCell>
-                                            <TableCell>
-                                                <Button size="small" onClick={() => handleRowClick(file)}>View</Button>
-                                            </TableCell>
-                                        </TableRow>
-                                    ))}
+                                    {filesData.map((file) => {
+                                        const removedCellSx = file.removed
+                                            ? { textDecoration: 'line-through', color: 'text.disabled' }
+                                            : {};
+                                        return (
+                                            <TableRow
+                                                key={file.filename}
+                                                onClick={() => handleRowClick(file)}
+                                                selected={selectedFile?.filename === file.filename}
+                                                sx={{
+                                                    cursor: file.removed ? 'default' : 'pointer',
+                                                    '&:hover': file.removed ? {} : { backgroundColor: 'action.hover' },
+                                                }}
+                                            >
+                                                <TableCell sx={removedCellSx}>{format(new Date(file.timestamp), 'yyyy-MM-dd HH:mm:ss')}</TableCell>
+                                                <TableCell sx={removedCellSx}>{file.hostname || 'N/A'}</TableCell>
+                                                <TableCell sx={removedCellSx}>
+                                                    {file.perf_events && file.perf_events.length > 0
+                                                        ? file.perf_events.join(', ')
+                                                        : 'N/A'}
+                                                </TableCell>
+                                                <TableCell sx={removedCellSx}>{(file.size / 1024).toFixed(2)} KB</TableCell>
+                                                <TableCell>
+                                                    {file.removed
+                                                        ? <Chip label="Removed" size="small" color="error" variant="outlined" />
+                                                        : <Button size="small" onClick={(e) => { e.stopPropagation(); handleRowClick(file); }}>View</Button>
+                                                    }
+                                                </TableCell>
+                                            </TableRow>
+                                        );
+                                    })}
                                 </TableBody>
                             </Table>
                         </TableContainer>


### PR DESCRIPTION
# Adhoc Flamegraphs: Mark S3-Removed Files in UI

## Overview

Adds a `removed` flag to adhoc flamegraph entries that indicates whether the underlying file is still present in S3. The backend detects removal efficiently using parallel S3 HEAD requests, and the frontend renders removed entries with a distinct visual treatment so users know the file is no longer available.

## Problem

The adhoc flamegraph list is sourced from the database (populated by the indexer). However, S3 objects can be deleted independently (e.g. via lifecycle policies or manual cleanup) without the DB being updated. This caused the UI to show files that could no longer actually be viewed, leading to silent failures when trying to load them.

## Strategy

S3 does not provide a native batch existence check API. Two approaches were considered and rejected:

- **Prefix listing (`list_objects_v2`)**: would work for small buckets but is unacceptable at scale — with 100k hosts generating files every minute, a prefix scan would return millions of irrelevant keys per request.
- **Sequential `head_object` per file**: one S3 API call per entry, serialized — total latency grows linearly.

The chosen approach: **parallel `head_object` calls via `ThreadPoolExecutor`**. The DB query is always scoped to a service + time range + optional hostname filters, so the result set is a small bounded list (typically tens to low hundreds of files). All HEAD requests are dispatched simultaneously, making the total latency approximately equal to a single S3 round-trip regardless of list size.

`asyncio` with `aiobotocore` was also considered but rejected — the endpoint is synchronous (`def`), boto3 is blocking, and introducing `aiobotocore` would be a significant dependency change for no practical gain over `ThreadPoolExecutor`.

## Modified Files

- **`src/gprofiler-dev/gprofiler_dev/s3_profile_dal.py`**  
  Added `check_keys_exist(keys: List[str]) -> Set[str]` method to `S3ProfileDal`. Uses `ThreadPoolExecutor` (capped at 32 workers) to fire all `head_object` calls in parallel. Returns a set of keys confirmed to exist in S3.

- **`src/gprofiler/backend/routers/metrics_routes.py`**  
  Added `removed: bool = False` field to the `FlamegraphFile` response model. After building the flamegraph list from DB metadata, calls `check_keys_exist` once and stamps `removed = True` on any entry whose S3 key was absent. Removed entries are still included in the response — the frontend controls visibility.

- **`src/gprofiler/frontend/src/components/profiles/views/adhoc/AdhocProfilingView.jsx`**  
  Consumes the `removed` field to differentiate unavailable entries in the UI:
  - Table rows for removed files show strikethrough text with `text.disabled` color and an outlined red **Removed** chip in the action column instead of the View button.
  - Clicking or hovering on removed rows has no effect.
  - The dropdown selector disables removed entries and appends `(removed)` to their label.
