### PR TITLE
Fix nodes_cores_summary crashes when profiler data is empty

### DIFF
--- a/src/gprofiler-dev/gprofiler_dev/postgres/db_manager.py
+++ b/src/gprofiler-dev/gprofiler_dev/postgres/db_manager.py
@@ -453,7 +453,7 @@ class DBManager(metaclass=Singleton):
         end_time: datetime,
         ignore_zeros: bool,
         hostname: Optional[str],
-    ) -> Dict:
+    ) -> Dict[str, Optional[float]]:
         total_seconds = (end_time - start_time).total_seconds()
         values = {"service_id": service_id, "start_time": start_time, "end_time": end_time}
         if ignore_zeros:
@@ -465,9 +465,11 @@ class DBManager(metaclass=Singleton):
                 fetch_all=True,
             )
             if not res:
-                return res
+                return {"avg_cores": None, "avg_nodes": None}
             intervals = [(elem["first_seen"], elem["last_seen"]) for elem in res]
             total_seconds = get_total_seconds_from_intervals(intervals)
+            if total_seconds == 0:
+                return {"avg_cores": None, "avg_nodes": None}
 
         values["total_seconds"] = total_seconds
         if hostname:


### PR DESCRIPTION
When `ignore_zeros` is enabled and the service has no profiling data, `get_nodes_cores_summary` could return a raw list instead of the expected dict (causing `TypeError` on string key access) or pass `total_seconds=0` to SQL (causing `psycopg2.DivisionByZero`). Both cases are now handled by returning a stable `{"avg_cores": None, "avg_nodes": None}` fallback, which the route already translates into a `204 No Content` response.

## Description

Two defensive guards added to `get_nodes_cores_summary()` in `db_manager.py`:

1. **Empty result guard** — When `ignore_zeros=True` and the `PROFILER_PROCESS_TIMERANGES_BY_SERVICE` query returns no rows, the method was returning the raw empty list (`[]`). The caller in `metrics_routes.py` then tried `res["avg_cores"]`, raising `TypeError: list indices must be integers or slices, not str`. Now returns `{"avg_cores": None, "avg_nodes": None}` instead.

2. **Zero total_seconds guard** — When the intermediate query returns rows but all clipped intervals are zero-width, `get_total_seconds_from_intervals()` returns `0.0`. This was passed as `%(total_seconds)s` into SQL that divides by it, raising `psycopg2.errors.DivisionByZero`. Now returns the same fallback dict before reaching the SQL.

The method's return type annotation was also tightened from `Dict` to `Dict[str, Optional[float]]` to reflect the actual contract.

## Related Issue

No linked issue. Both errors were discovered at runtime when visiting the AdHoc view for a server with no profiling data.

## Motivation and Context

Navigating to the AdHoc option for an empty server triggered two unhandled crashes in the `/nodes_cores/summary` endpoint. The route already has logic to convert a `None/None` summary into a `204 No Content` response, but the DB layer was not returning the expected shape in these edge cases. This change aligns the DB method with the caller's contract.

## How Has This Been Tested?

- Manually reproduced both errors against a server with no profiling data and confirmed the endpoint now returns `204`.
- Verified that no existing tests reference `get_nodes_cores_summary`, `get_total_seconds_from_intervals`, or `DBManager` — so there is no risk of breaking existing test coverage.
- Linter passes on the changed file.

## Screenshots

N/A

## Checklist

- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.