### PR TITLE
CE-4169: Mark adhoc flamegraph timestamps as UTC

### DIFF
--- a/src/gprofiler/backend/routers/metrics_routes.py
+++ b/src/gprofiler/backend/routers/metrics_routes.py
@@ -1011,7 +1011,7 @@ def get_adhoc_flamegraphs(
 
             flamegraph_files.append(FlamegraphFile(
                 filename=filename,
-                timestamp=datetime.fromisoformat(metadata["start_time"]),
+                timestamp=datetime.fromisoformat(metadata["start_time"]).replace(tzinfo=timezone.utc),
                 hostname=metadata["hostname"],
                 size=metadata.get("file_size"),
                 s3_path=s3_key,


### PR DESCRIPTION
## Description

This PR fixes the `/api/metrics/adhoc_flamegraphs` response so adhoc flamegraph timestamps are returned as timezone-aware UTC datetimes.

Previously, the endpoint returned naive ISO timestamps like:

```json
"timestamp": "2026-04-14T23:57:11"
```

Browsers parse that format as local time, which caused the frontend to display adhoc flamegraph rows shifted by the user's timezone offset.

This change marks the timestamp as UTC when building the `FlamegraphFile` response model, so FastAPI serializes it with timezone information and the frontend parses it correctly.

## Related Issue

[CE-4169](https://pinterest.atlassian.net/browse/CE-4169)

## Motivation and Context

While testing locale-aware date formatting in `/profiles`, we found a separate timezone issue in the adhoc flamegraph API.

The UI correctly sends selected local time ranges to the backend as UTC ISO strings, but the backend response returned adhoc flamegraph timestamps without timezone information. This made `new Date(timestamp)` treat UTC timestamps as local timestamps, causing displayed adhoc times to be offset from the selected UI filter range.

## How Has This Been Tested?

- Manually tested `/api/metrics/adhoc_flamegraphs` with UTC `startTime` and `endTime` query parameters.
- Confirmed the returned adhoc timestamps fall within the expected UTC range.
- Confirmed that adding UTC timezone information fixes browser-side parsing and aligns displayed adhoc timestamps with the selected UI filter range.

## Screenshots

N/A

## Checklist:

- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
