### PR TITLE
Fix: nginx log rotation in gprofiler webapp container

### DIFF
--- a/src/gprofiler/nginx/logrotate.conf
+++ b/src/gprofiler/nginx/logrotate.conf
@@ -1,12 +1,15 @@
-"/var/log/nginx/access.log" {
-    rotate 1
-    size 100M
+/var/log/nginx/*.log {
+    daily
+    size 500M
+    rotate 7
     dateext
     dateformat -%Y-%m-%d
-    missingok
     compress
+    delaycompress
+    missingok
+    notifempty
     sharedscripts
     postrotate
-        test -r /var/run/nginx.pid && kill -USR1 `cat /var/run/nginx.pid`
+        test -r /run/nginx.pid && kill -USR1 `cat /run/nginx.pid`
     endscript
 }

--- a/src/gprofiler/run.sh
+++ b/src/gprofiler/run.sh
@@ -58,6 +58,7 @@ gunicorn_cmd_line=" --workers=${GUNICORN_PROCESS_COUNT} \
 function clean_up {
     kill "${GUNICORN_PID}"
     kill "${NGINX_PID}"
+    kill "${ROTATE_LOGS_PID}" 2>/dev/null || true
     if [[ "${CERT_RELOAD_PID:-}" != "" ]]; then
         kill "${CERT_RELOAD_PID}" 2>/dev/null || true
     fi
@@ -65,6 +66,14 @@ function clean_up {
 }
 trap clean_up SIGHUP SIGINT SIGTERM
 rm -f ${gunicorn_pid_file}
+
+# Background process for periodic log rotation
+function rotate_logs {
+    while true; do
+        sleep 900  # every 15 minutes
+        logrotate /etc/nginx/logrotate.conf
+    done
+}
 
 # Background process for periodic certificate reload
 function reload_certificates {
@@ -84,6 +93,10 @@ GUNICORN_PID=$!
 nginx -g "daemon off;" &
 NGINX_PID=$!
 
+# Start log rotation background process
+rotate_logs &
+ROTATE_LOGS_PID=$!
+
 # Start certificate reload process if enabled
 if [[ "${ENABLE_CERT_RELOAD}" == "true" ]]; then
     echo "Certificate auto-reload enabled (period: ${CERT_RELOAD_PERIOD} seconds)"
@@ -93,4 +106,4 @@ else
     echo "Certificate auto-reload disabled"
 fi
 
-wait ${GUNICORN_PID} ${NGINX_PID}
+wait ${GUNICORN_PID} ${NGINX_PID} ${ROTATE_LOGS_PID}


### PR DESCRIPTION
# Fix: nginx log rotation in gprofiler webapp container

## Problem

The gprofiler webapp container (`src/gprofiler/Dockerfile`) had no working log rotation at runtime. Two separate issues compounded this:

1. **Build-time no-op**: `RUN logrotate /etc/nginx/logrotate.conf` in the Dockerfile runs at image build time — before any logs exist — so it only initialises the logrotate state file and does nothing for runtime rotation.
2. **No scheduling in the container**: `run.sh` never invoked logrotate periodically. The only scheduled logrotate call existed in the `periodic_tasks` container (`deploy/periodic_tasks/crontab`), which runs in a separate pod and has no access to this container's filesystem. In a deployment where only the gprofiler webapp image is provisioned, `/var/log/nginx/access.log` would grow unbounded indefinitely.

Additionally, the logrotate config itself had several deficiencies:
- Only targeted `access.log` by exact quoted path; `error.log` and any future logs were not covered.
- `rotate 1` meant virtually no log retention.
- No `daily` trigger — rotation would never occur on low-traffic days where 100M was never reached.
- Wrong PID path (`/var/run/nginx.pid` vs the actual `/run/nginx.pid` declared in `nginx.conf`).
- Missing `delaycompress` and `notifempty`.

## Solution

### `src/gprofiler/run.sh`

Added a `rotate_logs` background function that calls `logrotate` every 15 minutes (matching the `periodic_tasks` crontab interval), started alongside gunicorn and nginx at container startup:

```bash
function rotate_logs {
    while true; do
        sleep 900  # every 15 minutes
        logrotate /etc/nginx/logrotate.conf
    done
}
```

- Background PID is captured as `ROTATE_LOGS_PID`.
- Killed cleanly in the `clean_up` trap on `SIGHUP`/`SIGINT`/`SIGTERM`.
- Added to the final `wait` so the container lifecycle is tied to all three processes.

### `src/gprofiler/nginx/logrotate.conf`

| Setting | Before | After | Reason |
|---|---|---|---|
| Target | `"/var/log/nginx/access.log"` | `/var/log/nginx/*.log` | Covers all nginx logs |
| `rotate` | 1 | 7 | 7 days retention for incident investigation |
| `daily` | — | added | Guarantees rotation regardless of traffic volume |
| `size` | 100M | 500M | Appropriate for up to ~3,000 QPS peak traffic |
| `delaycompress` | — | added | Most recent rotated file stays uncompressed for easy access |
| `notifempty` | — | added | Skips rotation of empty log files |
| PID path | `/var/run/nginx.pid` | `/run/nginx.pid` | Matches `pid /run/nginx.pid;` in `nginx.conf` |

`copytruncate` was intentionally **not** adopted from an alternative suggestion — it has a race window between copy and truncation that can silently drop log lines. The `postrotate`/`SIGUSR1` approach is the correct nginx pattern and works cleanly since `/run/nginx.pid` is owned by the `non_root` user.

## Files changed

- `src/gprofiler/run.sh` — added `rotate_logs` background loop
- `src/gprofiler/nginx/logrotate.conf` — improved rotation rules

## Tests

The container was provisioned locally using a simplified logrotate config with a 1k size threshold to trigger rotation without needing to generate real traffic:

```
/var/log/nginx/*.log {
    size 1k
    rotate 7
    dateext
    dateformat -%Y-%m-%d
    compress
    delaycompress
    missingok
    notifempty
    sharedscripts
    postrotate
        test -r /run/nginx.pid && kill -USR1 `cat /run/nginx.pid`
    endscript
}
```

Verified that:
- The `rotate_logs` background loop in `run.sh` invokes logrotate at the expected interval.
- Log files are rotated and compressed correctly once the size threshold is exceeded.
- nginx receives `SIGUSR1` and reopens its log file handles without interruption.
- The container shuts down cleanly and the `rotate_logs` process is properly terminated.
