### PR TITLE
Fix: logrotate postrotate script compatibility

### DIFF
--- a/src/gprofiler/nginx/logrotate.conf
+++ b/src/gprofiler/nginx/logrotate.conf
@@ -10,6 +10,6 @@
     notifempty
     sharedscripts
     postrotate
-        test -r /run/nginx.pid && kill -USR1 `cat /run/nginx.pid`
+        test -r /run/nginx.pid && kill -USR1 $(cat /run/nginx.pid)
     endscript
 }


### PR DESCRIPTION
# Fix: logrotate postrotate script compatibility

## Problem

The `postrotate` script in `src/gprofiler/nginx/logrotate.conf` used backtick syntax for command substitution:

```sh
test -r /run/nginx.pid && kill -USR1 `cat /run/nginx.pid`
```

logrotate executes `postrotate` scripts using `/bin/sh`, which on some systems (notably `dash`, the default `/bin/sh` on Debian/Ubuntu) produces:

```
logrotate_script: test: /run/nginx.pid: unexpected operator
error: error running shared postrotate script for '/var/log/nginx/*.log'
```

The rotation itself succeeds — log files are renamed correctly — but nginx never receives `SIGUSR1` and does not reopen its log file handles. This means nginx keeps writing to the renamed (rotated) archive file, leaving the new `access.log` empty until the next container restart.

## Fix

Replaced backtick with `$()` (POSIX-compatible command substitution), which is handled correctly by all `/bin/sh` implementations:

```sh
test -r /run/nginx.pid && kill -USR1 $(cat /run/nginx.pid)
```

## Files changed

- `src/gprofiler/nginx/logrotate.conf` — `postrotate` script fix