### PR TITLE
docs: refresh README architecture diagram to cover dynamic profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,54 +44,60 @@ same backend services and storage layer:
 
 ### Architecture diagram
 
-> The diagram is written in Mermaid so it stays diff-able. To export it as a PNG / SVG
-> for slides or docs, paste the source into [mermaid.live](https://mermaid.live)
-> and pick your preferred background — the theme below is tuned for a light grey canvas.
+> The diagram is written in Mermaid so it stays diff-able. The outer grey card and
+> rounded corners below render natively on GitHub via `style` directives and `rx`/`ry`
+> on each `classDef`. For a clean PNG / SVG export for slides or docs, paste the source
+> into [mermaid.live](https://mermaid.live) and use its **Background** picker (Mermaid
+> itself doesn't expose a `background` theme variable — the SVG is transparent and the
+> page CSS shows through).
 
 ```mermaid
 %%{init: {
   'theme': 'base',
   'themeVariables': {
-    'background': '#e5e7eb',
     'primaryColor': '#ffffff',
     'primaryBorderColor': '#cbd5e1',
     'primaryTextColor': '#0f172a',
     'lineColor': '#64748b',
     'fontFamily': 'Inter, ui-sans-serif, system-ui, sans-serif',
-    'fontSize': '14px',
-    'borderRadius': '8px'
+    'fontSize': '14px'
   }
 }}%%
 flowchart TB
-    classDef agent fill:#eaf2ff,stroke:#3b82f6,stroke-width:1.5px,color:#1e293b
-    classDef ui    fill:#fff4d6,stroke:#d97706,stroke-width:1.5px,color:#1e293b
-    classDef be    fill:#ece6ff,stroke:#7c3aed,stroke-width:1.5px,color:#1e293b
-    classDef store fill:#fde2f3,stroke:#db2777,stroke-width:1.5px,color:#1e293b
-    classDef aws   fill:#ffedd5,stroke:#ea580c,stroke-width:1.5px,color:#1e293b
+    classDef agent fill:#eaf2ff,stroke:#3b82f6,stroke-width:1.5px,color:#1e293b,rx:8,ry:8
+    classDef ui    fill:#fff4d6,stroke:#d97706,stroke-width:1.5px,color:#1e293b,rx:8,ry:8
+    classDef be    fill:#ece6ff,stroke:#7c3aed,stroke-width:1.5px,color:#1e293b,rx:8,ry:8
+    classDef store fill:#fde2f3,stroke:#db2777,stroke-width:1.5px,color:#1e293b,rx:8,ry:8
+    classDef aws   fill:#ffedd5,stroke:#ea580c,stroke-width:1.5px,color:#1e293b,rx:8,ry:8
 
-    AGENT["🖥️ <b>gProfiler Agent</b> (host)<br/>continuous + ad-hoc profiling<br/>+ optional Intel® PerfSpect HW metrics"]:::agent
-
-    subgraph UIBOX["🌐 Frontend UI"]
+    subgraph CANVAS[" "]
       direction TB
-      FG["Flame graphs &amp; search"]:::ui
-      CTRL["Dynamic profiling console<br/>Start / Stop · PIDs · PerfSpect"]:::ui
+
+      AGENT["🖥️ <b>gProfiler Agent</b> (host)<br/>continuous + ad-hoc profiling<br/>+ optional Intel® PerfSpect HW metrics"]:::agent
+
+      subgraph UIBOX["🌐 Frontend UI"]
+        direction TB
+        FG["Flame graphs &amp; search"]:::ui
+        CTRL["Dynamic profiling console<br/>Start / Stop · PIDs · PerfSpect"]:::ui
+      end
+
+      subgraph BEBOX["⚙️ Performance Studio Backend"]
+        direction TB
+        WEBAPP["<b>webapp / FastAPI</b><br/>profile_request · heartbeat<br/>command_completion · host_status"]:::be
+        LOGSVC["agents-logs-backend"]:::be
+        IDX["gprofiler_indexer"]:::be
+        REST["gprofiler_flamedb_rest"]:::be
+      end
+
+      PG[("🗄️ PostgreSQL<br/>HostHeartbeats · ProfilingRequests<br/>ProfilingCommands · service metadata")]:::store
+      CH[("🗄️ ClickHouse — flamedb")]:::store
+      S3["☁️ <b>AWS S3</b><br/>profile data + adhoc"]:::aws
+      SQS["☁️ <b>AWS SQS</b><br/>indexer queue"]:::aws
     end
 
-    subgraph BEBOX["⚙️ Performance Studio Backend"]
-      direction TB
-      WEBAPP["<b>webapp / FastAPI</b><br/>profile_request · heartbeat<br/>command_completion · host_status"]:::be
-      LOGSVC["agents-logs-backend"]:::be
-      IDX["gprofiler_indexer"]:::be
-      REST["gprofiler_flamedb_rest"]:::be
-    end
-
-    PG[("🗄️ PostgreSQL<br/>HostHeartbeats · ProfilingRequests<br/>ProfilingCommands · service metadata")]:::store
-    CH[("🗄️ ClickHouse — flamedb")]:::store
-    S3["☁️ <b>AWS S3</b><br/>profile data + adhoc"]:::aws
-    SQS["☁️ <b>AWS SQS</b><br/>indexer queue"]:::aws
-
-    style UIBOX fill:#fafafa,stroke:#e5e7eb,stroke-width:1px,color:#0f172a
-    style BEBOX fill:#fafafa,stroke:#e5e7eb,stroke-width:1px,color:#0f172a
+    style CANVAS fill:#e5e7eb,stroke:#cbd5e1,stroke-width:1px,color:#0f172a
+    style UIBOX  fill:#fafafa,stroke:#e5e7eb,stroke-width:1px,color:#0f172a
+    style BEBOX  fill:#fafafa,stroke:#e5e7eb,stroke-width:1px,color:#0f172a
 
     %% --- data plane (solid) ---
     AGENT -- "upload profile / adhoc" --> WEBAPP

--- a/README.md
+++ b/README.md
@@ -52,21 +52,8 @@ flowchart TB
     classDef store fill:#f1f5f9,stroke:#475569,color:#1a2740
     classDef aws fill:#fff7ed,stroke:#ea580c,color:#1a2740
 
-    subgraph AGENT["gProfiler Agent (host)"]
-        direction TB
-        HB["Heartbeat loop<br/>POST /api/metrics/heartbeat"]
-        CMQ["CommandManager<br/>(priority queue:<br/>stop &gt; ad-hoc &gt; continuous)"]
-        CS["ContinuousProfilerSlot"]
-        AS["AdhocProfilerSlot"]
-        PSI["PerfSpect installer<br/>(HW metrics, optional)"]
-        LOG["Agent logs"]
-        HB --> CMQ
-        CMQ --> CS
-        CMQ --> AS
-        CS -. enable_perfspect .-> PSI
-        AS -. enable_perfspect .-> PSI
-    end
-    class AGENT,HB,CMQ,CS,AS,PSI,LOG agent
+    AGENT["gProfiler Agent (host)<br/>• continuous + ad-hoc profiling<br/>• optional Intel® PerfSpect HW metrics"]
+    class AGENT agent
 
     subgraph UI["Frontend UI (src/gprofiler/frontend)"]
         FG["Flame graph &amp; search views"]
@@ -90,8 +77,7 @@ flowchart TB
     class S3,SQS aws
 
     %% --- Continuous data plane ---
-    CS -- "upload profile" --> WEBAPP
-    AS -- "upload adhoc flamegraph" --> WEBAPP
+    AGENT -- "upload profile / adhoc flamegraph" --> WEBAPP
     WEBAPP -- "store raw" --> S3
     WEBAPP -- "enqueue index task" --> SQS
     SQS -- "trigger" --> IDX
@@ -101,14 +87,14 @@ flowchart TB
     WEBAPP -- "query flames" --> REST
 
     %% --- Logs ---
-    LOG -- "POST agent logs" --> LOGSVC
+    AGENT -- "POST agent logs" --> LOGSVC
     LOGSVC --> PG
 
     %% --- Metadata ---
     WEBAPP <--> PG
 
     %% --- Dynamic profiling control plane ---
-    HB <==> |"heartbeat &uarr;<br/>command &darr;"| WEBAPP
+    AGENT <==> |"heartbeat &uarr;<br/>command &darr;"| WEBAPP
     CTRL -- "create profiling request" --> WEBAPP
 
     %% --- UI queries ---

--- a/README.md
+++ b/README.md
@@ -29,17 +29,120 @@ featuring advanced flamegraph analysis tools.
 
 
 ## System Overview
-![system_overview.png](system_overview.png)
-The Continuous Profiler is structured around several key microservices,
-each playing a vital role in its functionality:
 
-- `src/gprofiler/backend` - This is the web application backend. It exposes all APIs to the frontend or API users and is responsible for collecting data from agents.
-- `src/gprofiler/frontend` - The User Interface of Continuous Profiler, facilitating interaction with the backend.
-- `src/gprofiler_indexer` - This service is tasked with collecting raw profiling data from S3 storage and indexing it for ClickHouse, a database management system.
-- `src/gprofiler_flamedb_rest` - Handles communication with ClickHouse for the purpose of constructing flamegraphs.
-- `src/gprofiler_logging` - Dedicated to collecting logs from agents, ensuring a comprehensive logging system.
+The Continuous Profiler Performance Studio supports **two profiling modes** that share the
+same backend services and storage layer:
 
-This architecture allows for efficient handling and analysis of profiling data, providing users with an intuitive and powerful tool for performance analysis.
+1. **Continuous profiling (data plane)** — Agents periodically upload profile data which is
+   indexed into ClickHouse and visualized as flame graphs.
+2. **Dynamic profiling (control plane)** — Operators trigger ad-hoc / on-demand profiling
+   sessions from the UI; agents fetch start / stop commands via a heartbeat protocol and can
+   optionally collect Intel® PerfSpect hardware metrics. See
+   [`heartbeat_doc/README_HEARTBEAT.md`](heartbeat_doc/README_HEARTBEAT.md) and
+   [`heartbeat_doc/PERFSPECT_DYNAMIC_PROFILING.md`](heartbeat_doc/PERFSPECT_DYNAMIC_PROFILING.md)
+   for details.
+
+### Architecture diagram
+
+```mermaid
+flowchart TB
+    classDef agent fill:#eef4ff,stroke:#4c6ef5,color:#1a2740
+    classDef backend fill:#ede9fe,stroke:#7c3aed,color:#1a2740
+    classDef ui fill:#fef3c7,stroke:#d97706,color:#1a2740
+    classDef store fill:#f1f5f9,stroke:#475569,color:#1a2740
+    classDef aws fill:#fff7ed,stroke:#ea580c,color:#1a2740
+
+    subgraph AGENT["gProfiler Agent (host)"]
+        direction TB
+        HB["Heartbeat loop<br/>POST /api/metrics/heartbeat"]
+        CMQ["CommandManager<br/>(priority queue:<br/>stop &gt; ad-hoc &gt; continuous)"]
+        CS["ContinuousProfilerSlot"]
+        AS["AdhocProfilerSlot"]
+        PSI["PerfSpect installer<br/>(HW metrics, optional)"]
+        LOG["Agent logs"]
+        HB --> CMQ
+        CMQ --> CS
+        CMQ --> AS
+        CS -. enable_perfspect .-> PSI
+        AS -. enable_perfspect .-> PSI
+    end
+    class AGENT,HB,CMQ,CS,AS,PSI,LOG agent
+
+    subgraph UI["Frontend UI (src/gprofiler/frontend)"]
+        FG["Flame graph &amp; search views"]
+        CTRL["Dynamic profiling console<br/>Start / Stop, PIDs,<br/>PerfSpect HW metrics"]
+    end
+    class UI,FG,CTRL ui
+
+    subgraph BE["Performance Studio Backend"]
+        WEBAPP["webapp / backend (FastAPI)<br/>src/gprofiler/backend<br/>• /api/metrics/profile_request[/bulk]<br/>• /api/metrics/heartbeat<br/>• /api/metrics/command_completion<br/>• PMU + capacity validation<br/>• Slack notifications"]
+        LOGSVC["agents-logs-backend<br/>src/gprofiler_logging"]
+        IDX["gprofiler_indexer"]
+        REST["gprofiler_flamedb_rest"]
+    end
+    class BE,WEBAPP,LOGSVC,IDX,REST backend
+
+    PG[("PostgreSQL<br/>HostHeartbeats<br/>ProfilingRequests<br/>ProfilingCommands<br/>ProfilingExecutions<br/>service metadata")]
+    CH[("ClickHouse<br/>flamedb")]
+    S3[["AWS S3<br/>(profile data + adhoc)"]]
+    SQS[["AWS SQS<br/>(indexer queue)"]]
+    class PG,CH store
+    class S3,SQS aws
+
+    %% --- Continuous data plane ---
+    CS -- "upload profile" --> WEBAPP
+    AS -- "upload adhoc flamegraph" --> WEBAPP
+    WEBAPP -- "store raw" --> S3
+    WEBAPP -- "enqueue index task" --> SQS
+    SQS -- "trigger" --> IDX
+    IDX -- "read raw" --> S3
+    IDX -- "write samples" --> CH
+    REST -- "query" --> CH
+    WEBAPP -- "query flames" --> REST
+
+    %% --- Logs ---
+    LOG -- "POST agent logs" --> LOGSVC
+    LOGSVC --> PG
+
+    %% --- Metadata ---
+    WEBAPP <--> PG
+
+    %% --- Dynamic profiling control plane ---
+    HB <==> |"heartbeat &uarr;<br/>command &darr;"| WEBAPP
+    CTRL -- "create profiling request" --> WEBAPP
+
+    %% --- UI queries ---
+    FG -- "queries" --> WEBAPP
+```
+
+### Components
+
+The Performance Studio is structured around several key microservices:
+
+- `src/gprofiler/backend` — Web application backend (FastAPI). Exposes APIs to the frontend
+  and API users, ingests continuous profile data from agents, and hosts the **dynamic
+  profiling control plane** (`/api/metrics/heartbeat`, `/api/metrics/profile_request`,
+  `/api/metrics/profile_request/bulk`, `/api/metrics/command_completion`,
+  `/api/metrics/profiling/host_status`).
+- `src/gprofiler/frontend` — Web UI. Renders flame graphs and provides the dynamic
+  profiling console (Start / Stop, target hosts and PIDs, PerfSpect hardware-metrics
+  toggle).
+- `src/gprofiler_indexer` — Reads raw profiling data from S3 (triggered via SQS) and
+  indexes it into ClickHouse.
+- `src/gprofiler_flamedb_rest` — REST layer that the backend uses to query flame graphs
+  out of ClickHouse.
+- `src/gprofiler_logging` (`agents-logs-backend`) — Collects logs from agents.
+
+The **gProfiler agent** itself (see [intel/gprofiler](https://github.com/intel/gprofiler))
+runs on each profiled host and contributes two roles:
+
+- **Data plane** — Continuously uploads profile data to the backend.
+- **Control plane** — When started with `--enable-heartbeat-server`, runs a heartbeat
+  loop that fetches start / stop commands from the backend and dispatches them through a
+  `CommandManager` priority queue into one of two execution slots
+  (`ContinuousProfilerSlot`, `AdhocProfilerSlot`) which can run in parallel for
+  non-overlapping profiler types. Optionally bootstraps Intel® PerfSpect for hardware
+  metrics collection.
 
 ### External Dependencies: AWS Services
 The Continuous Profiler incorporates specific AWS services as essential components.
@@ -51,6 +154,10 @@ These dependencies are:
 
 You are welcome to replace those services with other similar which implement the same API,
 like Minio for S3 and RabbitMQ for SQS.
+
+> **Note:** The legacy `system_overview.png` diagram only depicted the continuous data
+> plane and predates dynamic profiling. The Mermaid diagram above is the current source of
+> truth.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -44,12 +44,13 @@ same backend services and storage layer:
 
 ### Architecture diagram
 
-> The diagram is written in Mermaid so it stays diff-able. The outer grey card and
-> rounded corners below render natively on GitHub via `style` directives and `rx`/`ry`
-> on each `classDef`. For a clean PNG / SVG export for slides or docs, paste the source
-> into [mermaid.live](https://mermaid.live) and use its **Background** picker (Mermaid
-> itself doesn't expose a `background` theme variable — the SVG is transparent and the
-> page CSS shows through).
+> The diagram is written in Mermaid so it stays diff-able. The light-grey container
+> cards (Frontend UI, Performance Studio Backend) and rounded corners below render
+> natively on GitHub via `style` directives and `rx`/`ry` on each `classDef`. For a
+> clean PNG / SVG export for slides or docs, paste the source into
+> [mermaid.live](https://mermaid.live) and use its **Background** picker (Mermaid
+> itself doesn't expose a `background` theme variable — the SVG is transparent and
+> the page CSS shows through).
 
 ```mermaid
 %%{init: {
@@ -70,34 +71,29 @@ flowchart TB
     classDef store fill:#fde2f3,stroke:#db2777,stroke-width:1.5px,color:#1e293b,rx:8,ry:8
     classDef aws   fill:#ffedd5,stroke:#ea580c,stroke-width:1.5px,color:#1e293b,rx:8,ry:8
 
-    subgraph CANVAS[" "]
+    AGENT["🖥️ <b>gProfiler Agent</b> (host)<br/>continuous + ad-hoc profiling<br/>+ optional Intel® PerfSpect HW metrics"]:::agent
+
+    subgraph UIBOX["🌐 Frontend UI"]
       direction TB
-
-      AGENT["🖥️ <b>gProfiler Agent</b> (host)<br/>continuous + ad-hoc profiling<br/>+ optional Intel® PerfSpect HW metrics"]:::agent
-
-      subgraph UIBOX["🌐 Frontend UI"]
-        direction TB
-        FG["Flame graphs &amp; search"]:::ui
-        CTRL["Dynamic profiling console<br/>Start / Stop · PIDs · PerfSpect"]:::ui
-      end
-
-      subgraph BEBOX["⚙️ Performance Studio Backend"]
-        direction TB
-        WEBAPP["<b>webapp / FastAPI</b><br/>profile_request · heartbeat<br/>command_completion · host_status"]:::be
-        LOGSVC["agents-logs-backend"]:::be
-        IDX["gprofiler_indexer"]:::be
-        REST["gprofiler_flamedb_rest"]:::be
-      end
-
-      PG[("🗄️ PostgreSQL<br/>HostHeartbeats · ProfilingRequests<br/>ProfilingCommands · service metadata")]:::store
-      CH[("🗄️ ClickHouse — flamedb")]:::store
-      S3["☁️ <b>AWS S3</b><br/>profile data + adhoc"]:::aws
-      SQS["☁️ <b>AWS SQS</b><br/>indexer queue"]:::aws
+      FG["Flame graphs &amp; search"]:::ui
+      CTRL["Dynamic profiling console<br/>Start / Stop · PIDs · PerfSpect"]:::ui
     end
 
-    style CANVAS fill:#f1f5f9,stroke:#e2e8f0,stroke-width:1px,color:#0f172a
-    style UIBOX  fill:#fafafa,stroke:#e5e7eb,stroke-width:1px,color:#0f172a
-    style BEBOX  fill:#fafafa,stroke:#e5e7eb,stroke-width:1px,color:#0f172a
+    subgraph BEBOX["⚙️ Performance Studio Backend"]
+      direction TB
+      WEBAPP["<b>webapp / FastAPI</b><br/>profile_request · heartbeat<br/>command_completion · host_status"]:::be
+      LOGSVC["agents-logs-backend"]:::be
+      IDX["gprofiler_indexer"]:::be
+      REST["gprofiler_flamedb_rest"]:::be
+    end
+
+    PG[("🗄️ PostgreSQL<br/>HostHeartbeats · ProfilingRequests<br/>ProfilingCommands · service metadata")]:::store
+    CH[("🗄️ ClickHouse — flamedb")]:::store
+    S3["☁️ <b>AWS S3</b><br/>profile data + adhoc"]:::aws
+    SQS["☁️ <b>AWS SQS</b><br/>indexer queue"]:::aws
+
+    style UIBOX fill:#f1f5f9,stroke:#e2e8f0,stroke-width:1px,color:#0f172a
+    style BEBOX fill:#f1f5f9,stroke:#e2e8f0,stroke-width:1px,color:#0f172a
 
     %% --- data plane (solid) ---
     AGENT -- "upload profile / adhoc" --> WEBAPP

--- a/README.md
+++ b/README.md
@@ -44,62 +44,76 @@ same backend services and storage layer:
 
 ### Architecture diagram
 
+> The diagram is written in Mermaid so it stays diff-able. To export it as a PNG / SVG
+> for slides or a blog post, paste the source into [mermaid.live](https://mermaid.live)
+> and pick your preferred background — the theme below is tuned for a light grey canvas.
+
 ```mermaid
+%%{init: {
+  'theme': 'base',
+  'themeVariables': {
+    'background': '#f3f4f6',
+    'primaryColor': '#ffffff',
+    'primaryBorderColor': '#cbd5e1',
+    'primaryTextColor': '#0f172a',
+    'lineColor': '#64748b',
+    'fontFamily': 'Inter, ui-sans-serif, system-ui, sans-serif',
+    'fontSize': '14px'
+  }
+}}%%
 flowchart TB
-    classDef agent fill:#eef4ff,stroke:#4c6ef5,color:#1a2740
-    classDef backend fill:#ede9fe,stroke:#7c3aed,color:#1a2740
-    classDef ui fill:#fef3c7,stroke:#d97706,color:#1a2740
-    classDef store fill:#f1f5f9,stroke:#475569,color:#1a2740
-    classDef aws fill:#fff7ed,stroke:#ea580c,color:#1a2740
+    classDef agent fill:#eaf2ff,stroke:#3b82f6,stroke-width:1.5px,color:#1e293b
+    classDef ui    fill:#fff4d6,stroke:#d97706,stroke-width:1.5px,color:#1e293b
+    classDef be    fill:#ece6ff,stroke:#7c3aed,stroke-width:1.5px,color:#1e293b
+    classDef store fill:#fde2f3,stroke:#db2777,stroke-width:1.5px,color:#1e293b
+    classDef aws   fill:#ffedd5,stroke:#ea580c,stroke-width:1.5px,color:#1e293b
 
-    AGENT["gProfiler Agent (host)<br/>• continuous + ad-hoc profiling<br/>• optional Intel® PerfSpect HW metrics"]
-    class AGENT agent
+    AGENT["🖥️ <b>gProfiler Agent</b> (host)<br/>continuous + ad-hoc profiling<br/>+ optional Intel® PerfSpect HW metrics"]:::agent
 
-    subgraph UI["Frontend UI (src/gprofiler/frontend)"]
-        FG["Flame graph &amp; search views"]
-        CTRL["Dynamic profiling console<br/>Start / Stop, PIDs,<br/>PerfSpect HW metrics"]
+    subgraph UIBOX["🌐 Frontend UI"]
+      direction TB
+      FG["Flame graphs &amp; search"]:::ui
+      CTRL["Dynamic profiling console<br/>Start / Stop · PIDs · PerfSpect"]:::ui
     end
-    class UI,FG,CTRL ui
 
-    subgraph BE["Performance Studio Backend"]
-        WEBAPP["webapp / backend (FastAPI)<br/>src/gprofiler/backend<br/>• /api/metrics/profile_request[/bulk]<br/>• /api/metrics/heartbeat<br/>• /api/metrics/command_completion<br/>• PMU + capacity validation<br/>• Slack notifications"]
-        LOGSVC["agents-logs-backend<br/>src/gprofiler_logging"]
-        IDX["gprofiler_indexer"]
-        REST["gprofiler_flamedb_rest"]
+    subgraph BEBOX["⚙️ Performance Studio Backend"]
+      direction TB
+      WEBAPP["<b>webapp / FastAPI</b><br/>profile_request · heartbeat<br/>command_completion · host_status"]:::be
+      LOGSVC["agents-logs-backend"]:::be
+      IDX["gprofiler_indexer"]:::be
+      REST["gprofiler_flamedb_rest"]:::be
     end
-    class BE,WEBAPP,LOGSVC,IDX,REST backend
 
-    PG[("PostgreSQL<br/>HostHeartbeats<br/>ProfilingRequests<br/>ProfilingCommands<br/>ProfilingExecutions<br/>service metadata")]
-    CH[("ClickHouse<br/>flamedb")]
-    S3[["AWS S3<br/>(profile data + adhoc)"]]
-    SQS[["AWS SQS<br/>(indexer queue)"]]
-    class PG,CH store
-    class S3,SQS aws
+    PG[("🗄️ PostgreSQL<br/>HostHeartbeats · ProfilingRequests<br/>ProfilingCommands · service metadata")]:::store
+    CH[("🗄️ ClickHouse — flamedb")]:::store
+    S3[["☁️ AWS S3"]]:::aws
+    SQS[["☁️ AWS SQS"]]:::aws
 
-    %% --- Continuous data plane ---
-    AGENT -- "upload profile / adhoc flamegraph" --> WEBAPP
+    style UIBOX fill:#fafafa,stroke:#e5e7eb,stroke-width:1px,color:#0f172a
+    style BEBOX fill:#fafafa,stroke:#e5e7eb,stroke-width:1px,color:#0f172a
+
+    %% --- data plane (solid) ---
+    AGENT -- "upload profile / adhoc" --> WEBAPP
     WEBAPP -- "store raw" --> S3
-    WEBAPP -- "enqueue index task" --> SQS
+    WEBAPP -- "enqueue" --> SQS
     SQS -- "trigger" --> IDX
     IDX -- "read raw" --> S3
     IDX -- "write samples" --> CH
+    WEBAPP <--> REST
     REST -- "query" --> CH
-    WEBAPP -- "query flames" --> REST
-
-    %% --- Logs ---
-    AGENT -- "POST agent logs" --> LOGSVC
+    AGENT -- "agent logs" --> LOGSVC
     LOGSVC --> PG
-
-    %% --- Metadata ---
     WEBAPP <--> PG
-
-    %% --- Dynamic profiling control plane ---
-    AGENT <==> |"heartbeat &uarr;<br/>command &darr;"| WEBAPP
-    CTRL -- "create profiling request" --> WEBAPP
-
-    %% --- UI queries ---
     FG -- "queries" --> WEBAPP
+
+    %% --- control plane (dashed) ---
+    AGENT <-. "heartbeat ↑ / command ↓" .-> WEBAPP
+    CTRL -. "profiling request" .-> WEBAPP
 ```
+
+**Legend.** Solid arrows are the continuous **data plane** (profile upload → S3 → SQS →
+indexer → ClickHouse → flame graphs). Dashed arrows are the dynamic **control plane**
+(UI creates a profiling request; agent fetches start / stop commands via heartbeat).
 
 ### Components
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ same backend services and storage layer:
 ```mermaid
 %%{init: {
   'theme': 'base',
+  'flowchart': { 'defaultRenderer': 'elk' },
   'themeVariables': {
     'primaryColor': '#ffffff',
     'primaryBorderColor': '#cbd5e1',

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ flowchart TB
       SQS["☁️ <b>AWS SQS</b><br/>indexer queue"]:::aws
     end
 
-    style CANVAS fill:#e5e7eb,stroke:#cbd5e1,stroke-width:1px,color:#0f172a
+    style CANVAS fill:#f1f5f9,stroke:#e2e8f0,stroke-width:1px,color:#0f172a
     style UIBOX  fill:#fafafa,stroke:#e5e7eb,stroke-width:1px,color:#0f172a
     style BEBOX  fill:#fafafa,stroke:#e5e7eb,stroke-width:1px,color:#0f172a
 

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ flowchart TB
 
     PG[("🗄️ PostgreSQL<br/>HostHeartbeats · ProfilingRequests<br/>ProfilingCommands · service metadata")]:::store
     CH[("🗄️ ClickHouse — flamedb")]:::store
-    S3[["☁️ AWS S3"]]:::aws
-    SQS[["☁️ AWS SQS"]]:::aws
+    S3["☁️ <b>AWS S3</b><br/>profile data + adhoc"]:::aws
+    SQS["☁️ <b>AWS SQS</b><br/>indexer queue"]:::aws
 
     style UIBOX fill:#fafafa,stroke:#e5e7eb,stroke-width:1px,color:#0f172a
     style BEBOX fill:#fafafa,stroke:#e5e7eb,stroke-width:1px,color:#0f172a

--- a/README.md
+++ b/README.md
@@ -45,20 +45,21 @@ same backend services and storage layer:
 ### Architecture diagram
 
 > The diagram is written in Mermaid so it stays diff-able. To export it as a PNG / SVG
-> for slides or a blog post, paste the source into [mermaid.live](https://mermaid.live)
+> for slides or docs, paste the source into [mermaid.live](https://mermaid.live)
 > and pick your preferred background — the theme below is tuned for a light grey canvas.
 
 ```mermaid
 %%{init: {
   'theme': 'base',
   'themeVariables': {
-    'background': '#f3f4f6',
+    'background': '#e5e7eb',
     'primaryColor': '#ffffff',
     'primaryBorderColor': '#cbd5e1',
     'primaryTextColor': '#0f172a',
     'lineColor': '#64748b',
     'fontFamily': 'Inter, ui-sans-serif, system-ui, sans-serif',
-    'fontSize': '14px'
+    'fontSize': '14px',
+    'borderRadius': '8px'
   }
 }}%%
 flowchart TB


### PR DESCRIPTION
## Summary

The legacy `system_overview.png` only depicts the one-way **continuous** data plane (agent → backend → S3 → indexer → ClickHouse) and predates the dynamic profiling work that has since landed (heartbeat protocol, `ProfilingRequests` / `ProfilingCommands` / `ProfilingExecutions`, two-slot agent, PerfSpect HW metrics, etc.).

This PR replaces the README's **System Overview** section with a Mermaid diagram that captures both the continuous data plane and the new dynamic profiling control plane, and expands the component list with the new endpoints. The legacy PNG is left in the repo and called out as legacy rather than deleted.

### What the new diagram shows

- **Agent (host)** — Heartbeat loop, `CommandManager` priority queue (stop > ad-hoc > continuous), `ContinuousProfilerSlot`, `AdhocProfilerSlot`, optional PerfSpect installer, agent logs.
- **Frontend UI** — Flame graph / search views and the Dynamic Profiling Console (Start / Stop, target hosts / PIDs, PerfSpect HW metrics checkbox).
- **Backend** — `webapp/backend` (FastAPI) including the new control-plane endpoints (`/api/metrics/heartbeat`, `/api/metrics/profile_request[/bulk]`, `/api/metrics/command_completion`, `/api/metrics/profiling/host_status`), `agents-logs-backend`, `gprofiler_indexer`, `gprofiler_flamedb_rest`.
- **Storage** — Postgres (HostHeartbeats, ProfilingRequests, ProfilingCommands, ProfilingExecutions, service metadata), ClickHouse (flamedb), S3, SQS.
- **Two flows**
  - Continuous data plane: `Slot → backend → S3 → SQS → indexer → ClickHouse → flamedb_rest → backend → UI`.
  - Dynamic profiling control plane: bidirectional `agent ⇄ backend` heartbeat / command, with the UI creating profiling requests through the same backend.

### Why not just regenerate the PNG

Mermaid renders natively on GitHub, lives next to the prose it describes, stays diff-able as the architecture evolves, and avoids drift between code and image-only docs. The legacy PNG remains available for historical reference.

## Test plan

- [ ] Verify the Mermaid diagram renders correctly on the GitHub PR / README preview.
- [ ] Sanity-check that all referenced components / endpoints exist in the codebase (`heartbeat_doc/README_HEARTBEAT.md`, `src/gprofiler/backend/routers/metrics_routes.py`, `src/gprofiler/frontend/src/components/console/ProfilingStatusPage.jsx`, `heartbeat_doc/PERFSPECT_DYNAMIC_PROFILING.md`).
- [ ] No source / build files were touched — docs-only change.

Made with [Cursor](https://cursor.com)