### PR TITLE
Add workload-aware profiling inventory and console views

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -29,6 +29,7 @@ on:
       - 'src/gprofiler/*.py'
       - 'src/gprofiler/backend/**'
       - 'src/gprofiler_logging/**'
+      - 'src/tests/**'
       - '.github/workflows/backend-ci.yml'
 
   # Allows you to run this workflow manually from the Actions tab
@@ -62,3 +63,26 @@ jobs:
 
       - name: Run linters
         run: ./lint.sh --ci
+
+  # Fast, in-process acceptance/spec tests: exercise the ProfilingRequest
+  # validator and the PMU/capacity guardrails directly (no server, no database).
+  spec-tests:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install minimal deps for fast spec tests
+        # Pinned to production's pydantic v1; boto3/psycopg2/json-logger are pulled
+        # in transitively when importing the backend package (gprofiler_dev).
+        run: |
+          python -m pip install --upgrade pip
+          pip install "pydantic[email]==1.10.14" "pyhumps==3.8.0" boto3 psycopg2-binary python-json-logger pytest
+
+      - name: Run fast backend spec tests
+        run: python -m pytest tests/spec -q
+        working-directory: ./src

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -97,3 +97,19 @@ jobs:
         if: github.ref == 'refs/heads/master'
         run: yarn build
         working-directory: ./src/gprofiler/frontend
+
+  # Fast, dependency-free acceptance/spec tests for the request-building logic
+  # (Node's built-in test runner; no yarn install or browser needed).
+  unit-tests:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.19"
+
+      - name: Run fast frontend spec tests
+        run: node --test src
+        working-directory: ./src/gprofiler/frontend

--- a/heartbeat_doc/WORKLOAD_LEVEL_PROFILING_SPEC.md
+++ b/heartbeat_doc/WORKLOAD_LEVEL_PROFILING_SPEC.md
@@ -1,0 +1,207 @@
+# Workload-Level Profiling Spec for Performance Studio
+
+## Purpose
+
+This spec defines the backend and UI design for workload-level profiling in
+Performance Studio. It also serves as the source-of-truth document for
+spec-driven development of future workload-selection and heartbeat-inventory
+changes in this repo.
+
+The design extends the existing heartbeat control plane rather than replacing
+it: the backend stores workload inventory from agent heartbeats, exposes
+workload-aware status views, and resolves workload selections into host/PID
+commands before dispatch.
+
+## Problem Statement
+
+The existing dynamic profiling flow is host-centric:
+
+- the UI shows one row per host
+- requests target `target_hosts`
+- the backend persists host heartbeats and host commands
+- the agent receives commands by host/service
+
+This is insufficient for Kubernetes-heavy deployments where users want to start
+profiling from the level they reason about operationally:
+
+- namespace
+- workload
+- pod
+- container
+- process
+
+## Goals
+
+1. Add workload-aware inventory without breaking the current heartbeat protocol.
+2. Keep command dispatch backward compatible with host-based agent execution.
+3. Let the UI present workload tabs and workload-aware confirmation summaries.
+4. Create a spec that future work can evolve first, before code changes.
+
+## Non-Goals
+
+- redesigning profiling commands around pod-native execution
+- adding a brand-new command queue model
+- guaranteeing globally stable Kubernetes workload IDs in v1
+- solving historical inventory retention beyond current heartbeat freshness
+
+## Design Principles
+
+- **Additive schema changes only** for heartbeat inventory fields.
+- **Backend resolution, agent execution**: workload targeting resolves to
+  host/PID mappings in the backend.
+- **Best-effort metadata**: missing namespace/pod/container fields must not
+  break host-level behavior.
+- **Freshness over history**: UI tabs represent active inventory from recent
+  heartbeats.
+
+## Data Model Changes
+
+`HostHeartbeats` is extended with:
+
+- `agent_version`
+- `run_mode`
+- `namespace`
+- `pod_name`
+- `containers jsonb`
+
+The `containers` payload stores the flattened workload inventory reported by the
+agent. Each container entry may include:
+
+- container identity
+- namespace/pod/workload metadata
+- process list
+
+`ProfilingRequests` remains API-level intent storage. Workload selectors are
+stored in `additional_args` as part of the request contract so the existing
+table does not need a full relational redesign in v1.
+
+## API Contract
+
+### Heartbeat Ingress
+
+The existing `POST /api/metrics/heartbeat` endpoint now accepts optional
+workload inventory fields:
+
+```json
+{
+  "hostname": "node-a",
+  "service_name": "checkout",
+  "namespace": "observability",
+  "pod_name": "gprofiler-abcde",
+  "agent_version": "1.2.3",
+  "run_mode": "k8s",
+  "containers": [
+    {
+      "container_name": "checkout",
+      "namespace": "shop",
+      "pod_name": "checkout-7f8d9",
+      "workload_name": "checkout",
+      "workload_kind": "k8s",
+      "processes": [
+        { "pid": 1234, "process_name": "java" }
+      ]
+    }
+  ]
+}
+```
+
+### Profiling Request Ingress
+
+The request contract is extended with:
+
+- `target_scope`
+- `target_entities`
+- optional `target_hosts` for pure host targeting
+
+Supported `target_scope` values:
+
+- `host`
+- `service`
+- `namespace`
+- `workload`
+- `pod`
+- `container`
+- `process`
+
+Each entry in `target_entities` may include service/namespace/host/pod/container
+and process selectors.
+
+## Resolution Model
+
+Before creating commands, the backend resolves workload selectors against the
+fresh heartbeat inventory:
+
+1. fetch recent host heartbeats for the service
+2. flatten `containers -> processes` into inventory records
+3. filter records by the requested scope and selectors
+4. convert the selection into:
+   - `hostname -> null` for host-wide execution
+   - `hostname -> [pid, ...]` for process-scoped execution
+
+The command queue remains unchanged after this resolution step.
+
+## UI Design
+
+The profiling console exposes tabs for:
+
+- Services
+- Namespaces
+- Hosts
+- Pods
+- Containers
+- Processes
+
+The same page also supports:
+
+- scope-aware filters
+- tab counts derived from active inventory
+- scope-aware selection summaries in the confirmation dialog
+- reuse of the existing bulk start/stop workflow
+
+## Freshness Rules
+
+Workload inventory is based on recent heartbeats only. The initial design uses
+the same active-host time window already used by the status page, so stale pods
+and containers naturally disappear when agents stop reporting them.
+
+## Failure Handling
+
+If workload resolution finds no active targets:
+
+- the API should reject the request with a clear validation error
+- no commands should be created
+
+If workload inventory is incomplete:
+
+- host-level targeting must continue to work
+- workload tabs may show partial data
+- the UI should not invent missing workload relationships
+
+## Backward Compatibility
+
+This design preserves compatibility because:
+
+- old heartbeats can omit new fields
+- old host-level requests still work
+- commands sent to agents remain host/PID based
+- the UI can still represent host-only rows
+
+## Spec-Driven Development Workflow
+
+All future workload-level backend or UI changes should follow:
+
+1. update this spec first
+2. describe contract/schema changes explicitly
+3. describe rollback and compatibility behavior
+4. implement code afterward
+5. keep the implementation aligned with the repo’s spec-driven guidance
+
+## Future Extensions
+
+Likely follow-up specs include:
+
+- durable workload identifiers and richer workload kinds
+- workload-level stop semantics that survive pod churn
+- historical inventory snapshots
+- workload-level flamegraph pivots and deep links
+- stronger validation for mixed host and workload selections

--- a/heartbeat_doc/WORKLOAD_LEVEL_PROFILING_SPEC.md
+++ b/heartbeat_doc/WORKLOAD_LEVEL_PROFILING_SPEC.md
@@ -265,6 +265,78 @@ This design preserves compatibility because:
 - commands sent to agents remain host/PID based
 - the UI can still represent host-only rows
 
+## Acceptance Tests
+
+These acceptance criteria define "done" for the studio side of workload-level
+profiling. They are written as Given/When/Then so they can drive spec-first
+development and be implemented as automated API/integration tests. The freshness
+window referenced below is the active-host heartbeat window (currently 2
+minutes).
+
+### Inventory & status views
+
+- **AT-S1 — Heartbeat populates inventory.** *Given* an agent posts a heartbeat
+  with `hostname`, `service_name`, optional `namespace`/`pod_name`, and
+  `containers[]` with processes, *When* it is stored, *Then*
+  `GET /api/metrics/profiling/workload_status?scope=host` returns a row for that
+  host while the heartbeat is within the freshness window.
+- **AT-S2 — Tab counts per scope.** *Given* a set of fresh heartbeats, *When*
+  `workload_status` is queried, *Then* `tabCounts` reports the correct number of
+  distinct groups for each of `service`, `namespace`, `host`, `pod`,
+  `container`, and `process`, and `activeHosts` equals the distinct fresh
+  hostnames.
+- **AT-S3 — Service tab is grouped by service.** *Given* multiple hosts of one
+  service, *When* `scope=service`, *Then* exactly **one** aggregated row is
+  returned per service (with host/pod/container/process counts), not one row per
+  host.
+- **AT-S4 — Freshness filtering.** *Given* a host whose latest heartbeat is older
+  than the freshness window, *When* `workload_status` is queried, *Then* that
+  host (and its pods/containers/processes) is excluded from all tabs.
+
+### Resolution & command creation
+
+- **AT-S5 — Host-level start.** *Given* `scope=host` targeting host `H`, *When* a
+  start request is submitted, *Then* a `start` command is created for `H` and is
+  returned to `H` on its next heartbeat with the requested config.
+- **AT-S6 — Service-level start fans out.** *Given* service `S` with hosts
+  `{H1, H2}`, *When* a `scope=service` start is submitted, *Then* a `start`
+  command is created for every current host of `S`.
+- **AT-S7 — Workload scope resolves to PIDs.** *Given* a `process`, `container`,
+  or `pod` selection, *When* a start request is submitted, *Then* it resolves to
+  `hostname -> [pid, ...]` and the resulting commands carry exactly those PIDs.
+- **AT-S8 — Empty resolution is rejected.** *Given* a selection that resolves to
+  zero active targets, *When* submitted, *Then* the API responds `422` and no
+  command is created.
+- **AT-S9 — PMU validation.** *Given* requested perf events that a target host
+  does not report in `supported_perf_events`, *When* a start is submitted with
+  perf enabled, *Then* the API rejects it with a clear per-host validation error.
+
+### Continuous service subscriptions & auto-enrollment
+
+- **AT-S10 — New host auto-enrolls.** *Given* service `S` has an active
+  service-wide continuous `start` subscription, *When* a host that was **not**
+  part of the original selection heartbeats for `S` and has no current command,
+  *Then* a `start` command (built from the subscription config) is created and
+  returned on that same heartbeat.
+- **AT-S11 — No subscription, no enrollment.** *Given* `S` has no active
+  subscription, *When* a new host heartbeats, *Then* no command is created.
+- **AT-S12 — Stop deactivates the subscription.** *Given* a service-wide `stop`
+  newer than the latest service-wide `start`, *When* a new host heartbeats for
+  `S`, *Then* it is **not** enrolled.
+- **AT-S13 — Existing command preserved.** *Given* a host already has a current
+  command, *When* it heartbeats under an active subscription, *Then*
+  auto-enrollment does **not** overwrite that command (explicit per-host actions
+  win).
+
+### Compatibility & failure handling
+
+- **AT-S14 — Legacy heartbeat.** *Given* a heartbeat without any workload fields,
+  *When* stored, *Then* host-level status and host/service commands still work,
+  and the host simply contributes no namespace/pod/container/process rows.
+- **AT-S15 — Partial inventory.** *Given* heartbeats missing some workload fields
+  (e.g. no `pod_name`), *When* tabs are computed, *Then* unaffected scopes still
+  return rows and the backend does not invent missing relationships.
+
 ## Spec-Driven Development Workflow
 
 All future workload-level backend or UI changes should follow:

--- a/heartbeat_doc/WORKLOAD_LEVEL_PROFILING_SPEC.md
+++ b/heartbeat_doc/WORKLOAD_LEVEL_PROFILING_SPEC.md
@@ -30,6 +30,37 @@ profiling from the level they reason about operationally:
 - container
 - process
 
+## Motivation
+
+Before this work, Performance Studio only supported **host-level** profiling:
+the user picked individual hosts and profiling commands were issued per host.
+Workload-level profiling exists to address two concrete operational pain points.
+
+### 1. Cluster churn breaks host-pinned profiling
+
+Hosts are constantly removed from and added to a cluster (autoscaling, spot
+reclamation, rolling replacements). With host-pinned selection, every time the
+fleet changes the user has to return to the UI and re-select hosts, and any
+host added after the original selection is simply **not profiled**.
+
+Workload-level profiling fixes this by letting the user select an entire
+**service** (and, in future, broader scopes). When a service is selected for
+continuous profiling, the selection is treated as a durable **subscription**:
+as new hosts for that service register via heartbeat, they are **immediately
+and automatically enrolled** in profiling — no manual re-selection. See
+[Continuous Service Subscriptions & Auto-Enrollment](#continuous-service-subscriptions--auto-enrollment).
+
+### 2. Users often want a specific process/container/pod, not whole hosts
+
+A host can run many workloads, but the user frequently cares about one
+container, pod, or process (e.g. a single Java service in a shared node). Whole-
+host profiling is both noisier and more expensive than necessary.
+
+Workload-level profiling lets the user target the precise scope they reason
+about (`namespace`, `workload`, `pod`, `container`, `process`) and the backend
+resolves that selection down to the exact `hostname -> [pid, ...]` mapping the
+agent executes. See [Resolution Model](#resolution-model).
+
 ## Goals
 
 1. Add workload-aware inventory without breaking the current heartbeat protocol.
@@ -139,6 +170,54 @@ fresh heartbeat inventory:
    - `hostname -> [pid, ...]` for process-scoped execution
 
 The command queue remains unchanged after this resolution step.
+
+## Continuous Service Subscriptions & Auto-Enrollment
+
+This realizes [Motivation #1](#1-cluster-churn-breaks-host-pinned-profiling):
+a service-wide continuous profiling request behaves as a standing subscription
+so that hosts which register *after* the request still get profiled.
+
+### Subscription definition
+
+A service is **actively subscribed** when its most recent service-scoped
+(`additional_args.target_scope == "service"`) continuous (`continuous == true`)
+`start` request in `ProfilingRequests` is newer than any service-scoped `stop`
+request for that service, and the start request was not cancelled.
+Implemented by `DBManager.get_active_service_subscription(service_name)`.
+
+### Auto-enrollment on heartbeat
+
+On every `POST /api/metrics/heartbeat`, after the host row is upserted, the
+backend calls `DBManager.auto_subscribe_host_to_service(hostname, service_name)`
+(see `receive_heartbeat`). The logic is:
+
+1. Look up the active service subscription. If none, do nothing.
+2. If the reporting host already has a current command, do nothing (so explicit
+   per-host actions — including stops — are preserved).
+3. Otherwise create a `start` command for the host, rebuilt from the
+   subscription request's stored configuration (frequency, duration, mode,
+   profiler configs). The command is created *before* the command lookup in the
+   same heartbeat, so the new host receives it on the very next response.
+
+### Behavior summary
+
+| Situation | Result |
+|-----------|--------|
+| New host heartbeats for a service with an active subscription | Auto-enrolled (start command created immediately) |
+| New host heartbeats for a service with no subscription | No command |
+| New host heartbeats after a service-wide stop | No command (stop is newer than start) |
+| Existing host already has a command | Left untouched |
+
+### Edge cases / limitations (v1)
+
+- Auto-enrollment only fires when a host has **no** current command. A host
+  whose previous command reached a terminal state (`completed`/`failed`) is not
+  re-enrolled in v1; continuous commands remain in `sent` state, so this is rare.
+- Subscriptions are scoped to `service` only. Namespace/pod/container/process
+  subscriptions are intentionally deferred (see Future Extensions).
+- A host-level stop issued while a service subscription is active will keep that
+  host stopped only until its command state is cleared; durable per-host opt-out
+  within a subscription is future work.
 
 ## UI Design
 

--- a/scripts/dev/seed_heartbeats.py
+++ b/scripts/dev/seed_heartbeats.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Local dev helper: send synthetic agent heartbeats to the Performance Studio.
+
+This populates HostHeartbeats so the Adhoc Profile Configuration page
+(/profiling) shows data across the Services / Namespaces / Hosts / Pods /
+Containers / Processes tabs. The workload_status API only returns hosts whose
+heartbeat_timestamp is within the last 2 minutes, so this script loops and
+re-sends heartbeats on an interval to keep the fleet "live".
+
+Usage:
+    python3 seed_heartbeats.py                # loop forever (default 45s)
+    python3 seed_heartbeats.py --once         # send a single round and exit
+    python3 seed_heartbeats.py --interval 30  # custom loop interval (seconds)
+
+Env / flags:
+    --base-url   default https://localhost:4433
+    --user/--password  basic-auth creds (default user/admin)
+"""
+import argparse
+import json
+import ssl
+import sys
+import time
+import urllib.request
+from datetime import datetime, timezone
+
+# Synthetic fleet: service -> list of host specs.
+# Each container carries a namespace/pod/workload plus a few processes so that
+# every scope tab (service/namespace/host/pod/container/process) has rows.
+RUNTIMES = {
+    "java": "java -Xmx4g -jar app.jar",
+    "python": "python3 /srv/app/server.py",
+    "node": "node dist/server.js",
+    "nginx": "nginx: master process",
+    "envoy": "/usr/local/bin/envoy -c /etc/envoy/envoy.yaml",
+    "go": "/srv/bin/service",
+}
+
+FLEET = [
+    {
+        "service": "ingress-webapp-canary-use1",
+        "namespace": "canary",
+        "agent_version": "1.53.1",
+        "hosts": [
+            {"host": "ip-10-0-1-245", "ip": "10.0.1.245",
+             "containers": [
+                 {"name": "webapp-nginx", "pod": "ingress-webapp-canary-a4b1", "kind": "Deployment",
+                  "procs": [("nginx", 7891), ("node", 9156)]},
+             ]},
+            {"host": "ip-10-0-2-156", "ip": "10.0.2.156",
+             "containers": [
+                 {"name": "webapp-api", "pod": "ingress-webapp-canary-77cd", "kind": "Deployment",
+                  "procs": [("java", 8234), ("python", 8412)]},
+             ]},
+            {"host": "ip-10-0-3-089", "ip": "10.0.3.089",
+             "containers": [
+                 {"name": "webapp-worker", "pod": "ingress-webapp-canary-2f0a", "kind": "Deployment",
+                  "procs": [("python", 9001)]},
+             ]},
+        ],
+    },
+    {
+        "service": "homefeed",
+        "namespace": "production",
+        "agent_version": "1.53.1",
+        "hosts": [
+            {"host": "ip-10-1-4-234", "ip": "10.1.4.234",
+             "containers": [
+                 {"name": "homefeed-app", "pod": "unity-homefeed-docker-prod-7d8f", "kind": "StatefulSet",
+                  "procs": [("node", 9156), ("go", 9210)]},
+             ]},
+            {"host": "ip-10-1-5-101", "ip": "10.1.5.101",
+             "containers": [
+                 {"name": "homefeed-ranker", "pod": "unity-homefeed-docker-prod-9911", "kind": "StatefulSet",
+                  "procs": [("java", 8801)]},
+             ]},
+        ],
+    },
+    {
+        "service": "unity-p2p",
+        "namespace": "production",
+        "agent_version": "1.53.1",
+        "hosts": [
+            {"host": "ip-10-1-6-12", "ip": "10.1.6.12",
+             "containers": [
+                 {"name": "unity-p2p-main", "pod": "unity-p2p-docker-prod-7d8f", "kind": "Deployment",
+                  "procs": [("java", 8234)]},
+                 {"name": "unity-p2p-sidecar", "pod": "unity-p2p-docker-prod-7d8f", "kind": "Deployment",
+                  "procs": [("envoy", 8421)]},
+             ]},
+        ],
+    },
+    {
+        "service": "ingress-trk-canary-use1",
+        "namespace": "staging",
+        "agent_version": "1.53.1",
+        "hosts": [
+            {"host": "ip-10-2-7-55", "ip": "10.2.7.55",
+             "containers": [
+                 {"name": "trk-collector", "pod": "ingress-trk-staging-1a2b", "kind": "DaemonSet",
+                  "procs": [("go", 7001)]},
+             ]},
+        ],
+    },
+    {
+        "service": "ingress-widgets-canary-use1",
+        "namespace": "development",
+        "agent_version": "1.53.1",
+        "hosts": [
+            {"host": "ip-10-3-8-77", "ip": "10.3.8.77",
+             "containers": [
+                 {"name": "widgets-web", "pod": "ingress-widgets-dev-9f2c", "kind": "Deployment",
+                  "procs": [("python", 6001), ("nginx", 6010)]},
+             ]},
+        ],
+    },
+]
+
+
+def build_heartbeats():
+    rounds = []
+    for svc in FLEET:
+        for host in svc["hosts"]:
+            containers = []
+            for c in host["containers"]:
+                containers.append({
+                    "containerId": f"{c['name']}-{host['host']}",
+                    "containerName": c["name"],
+                    "runtime": "containerd",
+                    "namespace": svc["namespace"],
+                    "podName": c["pod"],
+                    "workloadName": c["pod"].rsplit("-", 1)[0],
+                    "workloadKind": c["kind"],
+                    "processes": [
+                        {"pid": pid, "processName": RUNTIMES.get(rt, rt)}
+                        for (rt, pid) in c["procs"]
+                    ],
+                })
+            rounds.append({
+                "ip_address": host["ip"],
+                "hostname": host["host"],
+                "service_name": svc["service"],
+                "agent_version": svc["agent_version"],
+                "run_mode": "container",
+                "namespace": svc["namespace"],
+                "pod_name": host["containers"][0]["pod"],
+                "containers": containers,
+                "status": "active",
+                # Agent-normalized PMU event names (UI 'cpu-cycles' -> 'cycles')
+                "perf_supported_events": [
+                    "cycles", "instructions", "cache-misses", "cache-references",
+                    "branch-instructions", "branch-misses",
+                ],
+            })
+    return rounds
+
+
+def send(base_url, user, password, payloads):
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    mgr = urllib.request.HTTPPasswordMgrWithDefaultRealm()
+    mgr.add_password(None, base_url, user, password)
+    opener = urllib.request.build_opener(
+        urllib.request.HTTPBasicAuthHandler(mgr),
+        urllib.request.HTTPSHandler(context=ctx),
+    )
+    ok = 0
+    for hb in payloads:
+        hb["timestamp"] = datetime.now(timezone.utc).isoformat()
+        data = json.dumps(hb).encode("utf-8")
+        req = urllib.request.Request(
+            f"{base_url}/api/metrics/heartbeat", data=data,
+            headers={"Content-Type": "application/json"}, method="POST",
+        )
+        try:
+            with opener.open(req, timeout=10) as resp:
+                if resp.status == 200:
+                    ok += 1
+        except Exception as e:  # noqa: BLE001
+            print(f"  heartbeat failed for {hb['hostname']}: {e}", file=sys.stderr)
+    return ok
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base-url", default="https://localhost:4433")
+    ap.add_argument("--user", default="user")
+    ap.add_argument("--password", default="admin")
+    ap.add_argument("--interval", type=int, default=45)
+    ap.add_argument("--once", action="store_true")
+    args = ap.parse_args()
+
+    payloads = build_heartbeats()
+    print(f"Seeding {len(payloads)} hosts across {len(FLEET)} services to {args.base_url}")
+    while True:
+        ok = send(args.base_url, args.user, args.password, payloads)
+        print(f"[{datetime.now().strftime('%H:%M:%S')}] sent {ok}/{len(payloads)} heartbeats")
+        if args.once:
+            break
+        time.sleep(args.interval)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup/postgres/gprofiler_recreate.sql
+++ b/scripts/setup/postgres/gprofiler_recreate.sql
@@ -299,10 +299,11 @@ CREATE INDEX idx_hostheartbeats_heartbeat_timestamp ON HostHeartbeats (heartbeat
 CREATE INDEX idx_hostheartbeats_namespace ON HostHeartbeats (namespace);
 CREATE INDEX idx_hostheartbeats_pod_name ON HostHeartbeats (pod_name);
 
--- Structured workload inventory (normalized form of HostHeartbeats.containers).
--- Populated alongside the JSONB column during the transition; reads prefer these
--- tables and fall back to the JSONB snapshot for hosts that have not yet
--- re-heartbeated after a deploy.
+-- Structured workload inventory (normalized form of the container/process data
+-- reported in each heartbeat). Every process is scoped to a container, so this
+-- currently models containerized workloads only; non-containerized (e.g.
+-- systemd/bare-metal) processes are not represented here and are covered by
+-- host-scope profiling instead.
 CREATE TABLE HeartbeatContainers (
     id bigserial PRIMARY KEY,
     host_id bigint NOT NULL REFERENCES HostHeartbeats (ID) ON DELETE CASCADE,

--- a/scripts/setup/postgres/gprofiler_recreate.sql
+++ b/scripts/setup/postgres/gprofiler_recreate.sql
@@ -280,7 +280,6 @@ CREATE TABLE HostHeartbeats (
     run_mode text NULL,
     namespace text NULL,
     pod_name text NULL,
-    containers jsonb NOT NULL DEFAULT '[]'::jsonb,
     last_command_id uuid NULL,
     received_command_ids uuid[] NULL,
     executed_command_ids uuid[] NULL,
@@ -299,6 +298,41 @@ CREATE INDEX idx_hostheartbeats_status ON HostHeartbeats (status);
 CREATE INDEX idx_hostheartbeats_heartbeat_timestamp ON HostHeartbeats (heartbeat_timestamp);
 CREATE INDEX idx_hostheartbeats_namespace ON HostHeartbeats (namespace);
 CREATE INDEX idx_hostheartbeats_pod_name ON HostHeartbeats (pod_name);
+
+-- Structured workload inventory (normalized form of HostHeartbeats.containers).
+-- Populated alongside the JSONB column during the transition; reads prefer these
+-- tables and fall back to the JSONB snapshot for hosts that have not yet
+-- re-heartbeated after a deploy.
+CREATE TABLE HeartbeatContainers (
+    id bigserial PRIMARY KEY,
+    host_id bigint NOT NULL REFERENCES HostHeartbeats (ID) ON DELETE CASCADE,
+    container_id text NULL,
+    container_name text NULL,
+    runtime text NULL,
+    namespace text NULL,
+    pod_name text NULL,
+    workload_name text NULL,
+    workload_kind text NULL,
+    updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT unique_heartbeat_container UNIQUE (host_id, container_id)
+);
+
+CREATE INDEX idx_hb_containers_host_id ON HeartbeatContainers (host_id);
+CREATE INDEX idx_hb_containers_namespace ON HeartbeatContainers (namespace);
+CREATE INDEX idx_hb_containers_pod_name ON HeartbeatContainers (pod_name);
+CREATE INDEX idx_hb_containers_workload_name ON HeartbeatContainers (workload_name);
+
+CREATE TABLE HeartbeatProcesses (
+    id bigserial PRIMARY KEY,
+    container_row_id bigint NOT NULL REFERENCES HeartbeatContainers (id) ON DELETE CASCADE,
+    pid integer NOT NULL,
+    process_name text NULL,
+    updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT unique_heartbeat_process UNIQUE (container_row_id, pid)
+);
+
+CREATE INDEX idx_hb_processes_container_row_id ON HeartbeatProcesses (container_row_id);
+CREATE INDEX idx_hb_processes_process_name ON HeartbeatProcesses (process_name);
 
 -- Profiling Requests Table (simplified)
 CREATE TABLE ProfilingRequests (

--- a/scripts/setup/postgres/gprofiler_recreate.sql
+++ b/scripts/setup/postgres/gprofiler_recreate.sql
@@ -276,6 +276,11 @@ CREATE TABLE HostHeartbeats (
     hostname text NOT NULL,
     ip_address inet NOT NULL,
     service_name text NOT NULL,
+    agent_version text NULL,
+    run_mode text NULL,
+    namespace text NULL,
+    pod_name text NULL,
+    containers jsonb NOT NULL DEFAULT '[]'::jsonb,
     last_command_id uuid NULL,
     received_command_ids uuid[] NULL,
     executed_command_ids uuid[] NULL,
@@ -292,6 +297,8 @@ CREATE INDEX idx_hostheartbeats_hostname ON HostHeartbeats (hostname);
 CREATE INDEX idx_hostheartbeats_service_name ON HostHeartbeats (service_name);
 CREATE INDEX idx_hostheartbeats_status ON HostHeartbeats (status);
 CREATE INDEX idx_hostheartbeats_heartbeat_timestamp ON HostHeartbeats (heartbeat_timestamp);
+CREATE INDEX idx_hostheartbeats_namespace ON HostHeartbeats (namespace);
+CREATE INDEX idx_hostheartbeats_pod_name ON HostHeartbeats (pod_name);
 
 -- Profiling Requests Table (simplified)
 CREATE TABLE ProfilingRequests (

--- a/scripts/setup/postgres/migrations/add_structured_workload_inventory_tables.sql
+++ b/scripts/setup/postgres/migrations/add_structured_workload_inventory_tables.sql
@@ -1,0 +1,55 @@
+--
+-- Copyright (C) 2023 Intel Corporation
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--    http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+-- Normalized workload inventory tables.
+--
+-- These replace the per-host HostHeartbeats.containers JSONB snapshot with a
+-- structured, queryable model. During the transition the agent heartbeat path
+-- dual-writes both the JSONB column and these tables; reads prefer the tables
+-- and fall back to the JSONB snapshot for hosts that have not yet re-heartbeated.
+-- The JSONB column can be dropped in a follow-up migration once the structured
+-- path is proven.
+
+CREATE TABLE IF NOT EXISTS HeartbeatContainers (
+    id bigserial PRIMARY KEY,
+    host_id bigint NOT NULL REFERENCES HostHeartbeats (ID) ON DELETE CASCADE,
+    container_id text NULL,
+    container_name text NULL,
+    runtime text NULL,
+    namespace text NULL,
+    pod_name text NULL,
+    workload_name text NULL,
+    workload_kind text NULL,
+    updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT unique_heartbeat_container UNIQUE (host_id, container_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_hb_containers_host_id ON HeartbeatContainers (host_id);
+CREATE INDEX IF NOT EXISTS idx_hb_containers_namespace ON HeartbeatContainers (namespace);
+CREATE INDEX IF NOT EXISTS idx_hb_containers_pod_name ON HeartbeatContainers (pod_name);
+CREATE INDEX IF NOT EXISTS idx_hb_containers_workload_name ON HeartbeatContainers (workload_name);
+
+CREATE TABLE IF NOT EXISTS HeartbeatProcesses (
+    id bigserial PRIMARY KEY,
+    container_row_id bigint NOT NULL REFERENCES HeartbeatContainers (id) ON DELETE CASCADE,
+    pid integer NOT NULL,
+    process_name text NULL,
+    updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT unique_heartbeat_process UNIQUE (container_row_id, pid)
+);
+
+CREATE INDEX IF NOT EXISTS idx_hb_processes_container_row_id ON HeartbeatProcesses (container_row_id);
+CREATE INDEX IF NOT EXISTS idx_hb_processes_process_name ON HeartbeatProcesses (process_name);

--- a/scripts/setup/postgres/migrations/add_structured_workload_inventory_tables.sql
+++ b/scripts/setup/postgres/migrations/add_structured_workload_inventory_tables.sql
@@ -17,11 +17,10 @@
 -- Normalized workload inventory tables.
 --
 -- These replace the per-host HostHeartbeats.containers JSONB snapshot with a
--- structured, queryable model. During the transition the agent heartbeat path
--- dual-writes both the JSONB column and these tables; reads prefer the tables
--- and fall back to the JSONB snapshot for hosts that have not yet re-heartbeated.
--- The JSONB column can be dropped in a follow-up migration once the structured
--- path is proven.
+-- structured, queryable model. The heartbeat path writes the inventory into
+-- these tables, and inventory reads (target resolution and workload status)
+-- join/aggregate over them directly in SQL. The legacy JSONB column is removed
+-- by drop_containers_jsonb_from_hostheartbeats.sql.
 
 CREATE TABLE IF NOT EXISTS HeartbeatContainers (
     id bigserial PRIMARY KEY,

--- a/scripts/setup/postgres/migrations/add_workload_inventory_to_hostheartbeats.sql
+++ b/scripts/setup/postgres/migrations/add_workload_inventory_to_hostheartbeats.sql
@@ -1,0 +1,25 @@
+--
+-- Copyright (C) 2023 Intel Corporation
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--    http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+ALTER TABLE HostHeartbeats
+ADD COLUMN IF NOT EXISTS agent_version text NULL,
+ADD COLUMN IF NOT EXISTS run_mode text NULL,
+ADD COLUMN IF NOT EXISTS namespace text NULL,
+ADD COLUMN IF NOT EXISTS pod_name text NULL,
+ADD COLUMN IF NOT EXISTS containers jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+CREATE INDEX IF NOT EXISTS idx_hostheartbeats_namespace ON HostHeartbeats (namespace);
+CREATE INDEX IF NOT EXISTS idx_hostheartbeats_pod_name ON HostHeartbeats (pod_name);

--- a/scripts/setup/postgres/migrations/drop_containers_jsonb_from_hostheartbeats.sql
+++ b/scripts/setup/postgres/migrations/drop_containers_jsonb_from_hostheartbeats.sql
@@ -1,0 +1,28 @@
+--
+-- Copyright (C) 2023 Intel Corporation
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--    http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+-- Drop the transitional HostHeartbeats.containers JSONB snapshot.
+--
+-- Workload inventory now lives entirely in the normalized HeartbeatContainers /
+-- HeartbeatProcesses tables (see add_structured_workload_inventory_tables.sql).
+--
+-- DEPLOY ORDERING: apply this migration only AFTER the application code that no
+-- longer reads or writes the containers column is live. The current heartbeat
+-- write path stops populating this column and the read path no longer selects it,
+-- so once that build is deployed the column is dead and safe to drop.
+
+ALTER TABLE HostHeartbeats
+DROP COLUMN IF EXISTS containers;

--- a/src/gprofiler-dev/gprofiler_dev/postgres/db_manager.py
+++ b/src/gprofiler-dev/gprofiler_dev/postgres/db_manager.py
@@ -19,6 +19,7 @@ import json
 import threading
 import time
 import uuid
+import psycopg2.extras
 from collections import defaultdict
 from datetime import datetime, timedelta
 from secrets import token_urlsafe
@@ -881,14 +882,18 @@ class DBManager(metaclass=Singleton):
         if heartbeat_timestamp is None:
             heartbeat_timestamp = datetime.now()
 
+        # Container/process inventory lives entirely in the normalized
+        # HeartbeatContainers/HeartbeatProcesses tables (synced below). ``RETURNING ID``
+        # gives us the stable host row id (the upsert key is (hostname, service_name))
+        # used to attach those child rows.
         query = """
         INSERT INTO HostHeartbeats (
-            hostname, ip_address, service_name, agent_version, run_mode, namespace, pod_name, containers, last_command_id,
+            hostname, ip_address, service_name, agent_version, run_mode, namespace, pod_name, last_command_id,
             received_command_ids, executed_command_ids,
             status, heartbeat_timestamp, supported_perf_events, created_at, updated_at
         ) VALUES (
             %(hostname)s, %(ip_address)s::inet, %(service_name)s, %(agent_version)s, %(run_mode)s,
-            %(namespace)s, %(pod_name)s, %(containers)s::jsonb,
+            %(namespace)s, %(pod_name)s,
             %(last_command_id)s::uuid, %(received_command_ids)s::uuid[],
             %(executed_command_ids)s::uuid[],
             %(status)s::HostStatus,
@@ -901,7 +906,6 @@ class DBManager(metaclass=Singleton):
             run_mode = EXCLUDED.run_mode,
             namespace = EXCLUDED.namespace,
             pod_name = EXCLUDED.pod_name,
-            containers = EXCLUDED.containers,
             last_command_id = EXCLUDED.last_command_id,
             received_command_ids = EXCLUDED.received_command_ids,
             executed_command_ids = EXCLUDED.executed_command_ids,
@@ -909,6 +913,7 @@ class DBManager(metaclass=Singleton):
             heartbeat_timestamp = EXCLUDED.heartbeat_timestamp,
             supported_perf_events = EXCLUDED.supported_perf_events,
             updated_at = CURRENT_TIMESTAMP
+        RETURNING ID
         """
 
         values = {
@@ -919,7 +924,6 @@ class DBManager(metaclass=Singleton):
             "run_mode": run_mode,
             "namespace": namespace,
             "pod_name": pod_name,
-            "containers": json.dumps(containers or []),
             "last_command_id": last_command_id,
             "received_command_ids": received_command_ids,
             "executed_command_ids": executed_command_ids,
@@ -928,8 +932,84 @@ class DBManager(metaclass=Singleton):
             "supported_perf_events": supported_perf_events,
         }
 
-        self.db.execute(query, values, has_value=False)
+        # Host upsert and the normalized inventory sync share one transaction so a
+        # reader never observes a host whose structured inventory is half-written.
+        with self.db.transaction() as cursor:
+            cursor.execute(query, values)
+            row = cursor.fetchone()
+            host_id = row[0] if row else None
+            if host_id is not None:
+                self._sync_host_inventory(cursor, host_id, containers or [])
         return True
+
+    def _sync_host_inventory(self, cursor, host_id: int, containers: List[Dict[str, Any]]) -> None:
+        """Replace the normalized inventory for a host with the latest heartbeat snapshot.
+
+        Runs inside the caller's transaction. Uses delete-then-insert (the cascade on
+        HeartbeatContainers clears child processes) which keeps the logic simple and
+        guarantees the stored set exactly matches the heartbeat. A future optimization
+        is to diff against existing rows to reduce write churn on stable inventories.
+        """
+        cursor.execute("DELETE FROM HeartbeatContainers WHERE host_id = %s", (host_id,))
+
+        if not containers:
+            return
+
+        seen_container_ids: Set[str] = set()
+        for container in containers:
+            if not isinstance(container, dict):
+                continue
+
+            # Guard against duplicate non-null container_ids in a single payload,
+            # which would violate UNIQUE (host_id, container_id). NULL ids are allowed
+            # to repeat (Postgres treats NULLs as distinct).
+            container_id = container.get("container_id")
+            if container_id is not None:
+                if container_id in seen_container_ids:
+                    continue
+                seen_container_ids.add(container_id)
+
+            cursor.execute(
+                """
+                INSERT INTO HeartbeatContainers (
+                    host_id, container_id, container_name, runtime, namespace,
+                    pod_name, workload_name, workload_kind, updated_at
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, CURRENT_TIMESTAMP)
+                RETURNING id
+                """,
+                (
+                    host_id,
+                    container_id,
+                    container.get("container_name"),
+                    container.get("runtime"),
+                    container.get("namespace"),
+                    container.get("pod_name"),
+                    container.get("workload_name"),
+                    container.get("workload_kind"),
+                ),
+            )
+            container_row_id = cursor.fetchone()[0]
+
+            process_rows = []
+            seen_pids: Set[int] = set()
+            for process in container.get("processes") or []:
+                if not isinstance(process, dict):
+                    continue
+                pid = process.get("pid")
+                if pid is None or not str(pid).isdigit():
+                    continue
+                pid = int(pid)
+                if pid in seen_pids:  # satisfy UNIQUE (container_row_id, pid)
+                    continue
+                seen_pids.add(pid)
+                process_rows.append((container_row_id, pid, process.get("process_name")))
+
+            if process_rows:
+                psycopg2.extras.execute_values(
+                    cursor,
+                    "INSERT INTO HeartbeatProcesses (container_row_id, pid, process_name) VALUES %s",
+                    process_rows,
+                )
 
     def get_host_heartbeat(self, hostname: str) -> Optional[Dict]:
         """Get the latest heartbeat information for a host"""
@@ -1752,7 +1832,6 @@ class DBManager(metaclass=Singleton):
             h.run_mode,
             h.namespace,
             h.pod_name,
-            h.containers,
             h.heartbeat_timestamp,
             c.command_type,
             c.status,
@@ -1779,8 +1858,47 @@ class DBManager(metaclass=Singleton):
         query += " ORDER BY h.heartbeat_timestamp DESC"
         return self.db.execute(query, values, one_value=False, return_dict=True, fetch_all=True)
 
+    def _get_structured_inventory_by_host(self, host_ids: List[int]) -> Dict[int, List[Dict[str, Any]]]:
+        """Fetch the normalized container/process inventory for the given host rows.
+
+        Returns a map of host_id -> flattened rows. Each row is one (container, process)
+        pair; a container with no processes yields a single row with a NULL pid. This
+        mirrors the shape produced by flattening the JSONB snapshot, so callers can use
+        either source interchangeably.
+        """
+        if not host_ids:
+            return {}
+
+        query = """
+        SELECT
+            hc.host_id,
+            hc.container_id,
+            hc.container_name,
+            hc.namespace,
+            hc.pod_name,
+            hc.workload_name,
+            hc.workload_kind,
+            hp.pid,
+            hp.process_name
+        FROM HeartbeatContainers hc
+        LEFT JOIN HeartbeatProcesses hp ON hp.container_row_id = hc.id
+        WHERE hc.host_id = ANY(%(host_ids)s)
+        ORDER BY hc.id, hp.pid
+        """
+        rows = self.db.execute(
+            query, {"host_ids": host_ids}, one_value=False, return_dict=True, fetch_all=True
+        )
+
+        grouped: Dict[int, List[Dict[str, Any]]] = defaultdict(list)
+        for row in rows or []:
+            grouped[row["host_id"]].append(row)
+        return grouped
+
     def _build_inventory_records(self, heartbeat_rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         records: List[Dict[str, Any]] = []
+
+        host_ids = [row.get("id") for row in heartbeat_rows if row.get("id") is not None]
+        structured_by_host = self._get_structured_inventory_by_host(host_ids)
 
         for row in heartbeat_rows:
             command_metadata = self._extract_command_metadata(
@@ -1801,44 +1919,43 @@ class DBManager(metaclass=Singleton):
                 **command_metadata,
             }
 
-            containers = self._parse_json_field(row.get("containers"), []) or []
-            if not containers:
+            # Inventory comes from the normalized HeartbeatContainers/HeartbeatProcesses
+            # tables. Hosts with no container inventory (plain hosts, or workloads that
+            # report none) contribute a single host-level record.
+            structured_rows = structured_by_host.get(row.get("id"))
+            if structured_rows:
+                records.extend(self._records_from_structured(base_record, structured_rows))
+            else:
                 records.append(base_record.copy())
-                continue
 
-            for container in containers:
-                if not isinstance(container, dict):
-                    continue
+        return records
 
-                container_record = {
-                    **base_record,
-                    "container_id": container.get("container_id"),
-                    "container_name": container.get("container_name"),
-                    "namespace": container.get("namespace"),
-                    "pod_name": container.get("pod_name"),
-                    "workload_name": container.get("workload_name"),
-                    "workload_kind": container.get("workload_kind"),
-                }
-                processes = container.get("processes", []) or []
-                if not processes:
-                    records.append(container_record)
-                    continue
-
-                for process in processes:
-                    if not isinstance(process, dict):
-                        continue
-
-                    pid = process.get("pid")
-                    if not str(pid).isdigit():
-                        continue
-                    records.append(
-                        {
-                            **container_record,
-                            "pid": int(pid),
-                            "process_name": process.get("process_name"),
-                        }
-                    )
-
+    @staticmethod
+    def _records_from_structured(
+        base_record: Dict[str, Any], structured_rows: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        records: List[Dict[str, Any]] = []
+        for srow in structured_rows:
+            container_record = {
+                **base_record,
+                "container_id": srow.get("container_id"),
+                "container_name": srow.get("container_name"),
+                "namespace": srow.get("namespace"),
+                "pod_name": srow.get("pod_name"),
+                "workload_name": srow.get("workload_name"),
+                "workload_kind": srow.get("workload_kind"),
+            }
+            pid = srow.get("pid")
+            if pid is None:
+                records.append(container_record)
+            else:
+                records.append(
+                    {
+                        **container_record,
+                        "pid": int(pid),
+                        "process_name": srow.get("process_name"),
+                    }
+                )
         return records
 
     def _inventory_record_matches_filters(

--- a/src/gprofiler-dev/gprofiler_dev/postgres/db_manager.py
+++ b/src/gprofiler-dev/gprofiler_dev/postgres/db_manager.py
@@ -608,11 +608,16 @@ class DBManager(metaclass=Singleton):
         target_hostnames: Optional[List[str]] = None,
         pids: Optional[List[int]] = None,
         host_pid_mapping: Optional[Dict[str, List[int]]] = None,
+        target_scope: str = "host",
+        target_entities: Optional[List[Dict[str, Any]]] = None,
         additional_args: Optional[Dict] = None,
     ) -> bool:
         """Save a profiling request with support for host-to-PID mapping"""
         # Store additional_args WITHOUT host_pid_mapping (keep that separate)
         clean_additional_args = additional_args.copy() if additional_args else {}
+        clean_additional_args["target_scope"] = target_scope
+        if target_entities:
+            clean_additional_args["target_entities"] = target_entities
 
         # Store host_pid_mapping separately in a dedicated field if we add one,
         # for now, we'll handle it during command creation to avoid polluting additional_args
@@ -855,6 +860,11 @@ class DBManager(metaclass=Singleton):
         hostname: str,
         ip_address: str,
         service_name: str,
+        agent_version: Optional[str] = None,
+        run_mode: Optional[str] = None,
+        namespace: Optional[str] = None,
+        pod_name: Optional[str] = None,
+        containers: Optional[List[Dict[str, Any]]] = None,
         last_command_id: Optional[str] = None,
         received_command_ids: Optional[List[str]] = None,
         executed_command_ids: Optional[List[str]] = None,
@@ -872,11 +882,12 @@ class DBManager(metaclass=Singleton):
 
         query = """
         INSERT INTO HostHeartbeats (
-            hostname, ip_address, service_name, last_command_id,
+            hostname, ip_address, service_name, agent_version, run_mode, namespace, pod_name, containers, last_command_id,
             received_command_ids, executed_command_ids,
             status, heartbeat_timestamp, supported_perf_events, created_at, updated_at
         ) VALUES (
-            %(hostname)s, %(ip_address)s::inet, %(service_name)s,
+            %(hostname)s, %(ip_address)s::inet, %(service_name)s, %(agent_version)s, %(run_mode)s,
+            %(namespace)s, %(pod_name)s, %(containers)s::jsonb,
             %(last_command_id)s::uuid, %(received_command_ids)s::uuid[],
             %(executed_command_ids)s::uuid[],
             %(status)s::HostStatus,
@@ -885,6 +896,11 @@ class DBManager(metaclass=Singleton):
         ON CONFLICT (hostname, service_name)
         DO UPDATE SET
             ip_address = EXCLUDED.ip_address,
+            agent_version = EXCLUDED.agent_version,
+            run_mode = EXCLUDED.run_mode,
+            namespace = EXCLUDED.namespace,
+            pod_name = EXCLUDED.pod_name,
+            containers = EXCLUDED.containers,
             last_command_id = EXCLUDED.last_command_id,
             received_command_ids = EXCLUDED.received_command_ids,
             executed_command_ids = EXCLUDED.executed_command_ids,
@@ -898,6 +914,11 @@ class DBManager(metaclass=Singleton):
             "hostname": hostname,
             "ip_address": ip_address,
             "service_name": service_name,
+            "agent_version": agent_version,
+            "run_mode": run_mode,
+            "namespace": namespace,
+            "pod_name": pod_name,
+            "containers": json.dumps(containers or []),
             "last_command_id": last_command_id,
             "received_command_ids": received_command_ids,
             "executed_command_ids": executed_command_ids,
@@ -1539,6 +1560,482 @@ class DBManager(metaclass=Singleton):
 
         result = self.db.execute(query, values, one_value=True, return_dict=True)
         return result if result else None
+
+    @staticmethod
+    def _parse_json_field(value: Any, default: Any) -> Any:
+        if value is None:
+            return default
+        if isinstance(value, str):
+            try:
+                return json.loads(value)
+            except json.JSONDecodeError:
+                return default
+        return value
+
+    @staticmethod
+    def _matches_any_filter(value: Optional[Any], filters: Optional[List[Any]], exact_match: bool = False) -> bool:
+        if not filters:
+            return True
+        if value is None:
+            return False
+
+        value_str = str(value).lower()
+        for raw_filter in filters:
+            filter_str = str(raw_filter).lower()
+            if exact_match:
+                if value_str == filter_str:
+                    return True
+            elif filter_str in value_str:
+                return True
+        return False
+
+    @staticmethod
+    def _normalize_profiling_status(command_type: Optional[str], command_status: Optional[str]) -> str:
+        if command_status is None:
+            return "stopped"
+        if command_type == "start" and command_status in ["pending", "sent", "completed"]:
+            return "active"
+        return command_status
+
+    @staticmethod
+    def _summarize_enabled_profilers(combined_config: Dict[str, Any]) -> str:
+        profiler_configs = combined_config.get("profiler_configs", {}) or {}
+        if not profiler_configs:
+            return "Default"
+
+        profiler_labels = {
+            "perf": "Perf",
+            "async_profiler": "Java",
+            "pyperf": "Pyperf",
+            "pyspy": "Pyspy",
+            "rbspy": "Rbspy",
+            "phpspy": "PHPspy",
+            "dotnet_trace": ".NET",
+            "nodejs_perf": "NodeJS",
+        }
+        enabled = []
+        for key, label in profiler_labels.items():
+            value = profiler_configs.get(key)
+            if value is None:
+                continue
+            if isinstance(value, dict):
+                if value.get("enabled") is False or value.get("mode") == "disabled":
+                    continue
+            elif value == "disabled":
+                continue
+            enabled.append(label)
+        return ", ".join(enabled) if enabled else "Disabled"
+
+    def _extract_command_metadata(self, combined_config: Any, command_type: Optional[str], command_status: Optional[str]) -> Dict[str, Any]:
+        config = self._parse_json_field(combined_config, {}) or {}
+        current_pids = []
+        for pid in config.get("pids", []) or []:
+            if str(pid).isdigit():
+                current_pids.append(int(pid))
+
+        return {
+            "combined_config": config,
+            "pids": current_pids,
+            "frequency": config.get("frequency"),
+            "profiling_mode": "Continuous" if config.get("continuous") else "Ad Hoc",
+            "profiler_summary": self._summarize_enabled_profilers(config),
+            "command_type": command_type or "N/A",
+            "profiling_status": self._normalize_profiling_status(command_type, command_status),
+        }
+
+    def _get_recent_workload_heartbeat_rows(
+        self,
+        service_names: Optional[List[str]] = None,
+        exact_match: bool = False,
+    ) -> List[Dict[str, Any]]:
+        query = """
+        WITH latest_commands AS (
+            SELECT
+                pc.hostname,
+                pc.service_name,
+                pc.command_type,
+                pc.status,
+                pc.combined_config,
+                pc.created_at,
+                ROW_NUMBER() OVER (PARTITION BY pc.hostname, pc.service_name ORDER BY pc.created_at DESC) as rn
+            FROM ProfilingCommands pc
+        ),
+        current_commands AS (
+            SELECT
+                hostname,
+                service_name,
+                command_type,
+                status,
+                combined_config
+            FROM latest_commands
+            WHERE rn = 1
+        )
+        SELECT
+            h.id,
+            h.hostname,
+            h.ip_address,
+            h.service_name,
+            h.agent_version,
+            h.run_mode,
+            h.namespace,
+            h.pod_name,
+            h.containers,
+            h.heartbeat_timestamp,
+            c.command_type,
+            c.status,
+            c.combined_config
+        FROM HostHeartbeats h
+        LEFT JOIN current_commands c
+            ON h.hostname = c.hostname AND h.service_name = c.service_name
+        WHERE h.heartbeat_timestamp > NOW() - INTERVAL '2 minutes'
+        """
+
+        values: Dict[str, Any] = {}
+        if service_names:
+            if exact_match:
+                query += " AND h.service_name = ANY(%(service_names)s)"
+                values["service_names"] = service_names
+            else:
+                service_conditions = []
+                for idx, service_name in enumerate(service_names):
+                    param_name = f"service_name_{idx}"
+                    service_conditions.append(f"h.service_name ILIKE %({param_name})s")
+                    values[param_name] = f"%{service_name}%"
+                query += f" AND ({' OR '.join(service_conditions)})"
+
+        query += " ORDER BY h.heartbeat_timestamp DESC"
+        return self.db.execute(query, values, one_value=False, return_dict=True, fetch_all=True)
+
+    def _build_inventory_records(self, heartbeat_rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        records: List[Dict[str, Any]] = []
+
+        for row in heartbeat_rows:
+            command_metadata = self._extract_command_metadata(
+                row.get("combined_config"),
+                row.get("command_type"),
+                row.get("status"),
+            )
+            base_record = {
+                "host_id": row.get("id"),
+                "hostname": row.get("hostname"),
+                "ip_address": row.get("ip_address"),
+                "service_name": row.get("service_name"),
+                "agent_version": row.get("agent_version"),
+                "run_mode": row.get("run_mode"),
+                "agent_namespace": row.get("namespace"),
+                "agent_pod_name": row.get("pod_name"),
+                "heartbeat_timestamp": row.get("heartbeat_timestamp"),
+                **command_metadata,
+            }
+
+            containers = self._parse_json_field(row.get("containers"), []) or []
+            if not containers:
+                records.append(base_record.copy())
+                continue
+
+            for container in containers:
+                if not isinstance(container, dict):
+                    continue
+
+                container_record = {
+                    **base_record,
+                    "container_id": container.get("container_id"),
+                    "container_name": container.get("container_name"),
+                    "namespace": container.get("namespace"),
+                    "pod_name": container.get("pod_name"),
+                    "workload_name": container.get("workload_name"),
+                    "workload_kind": container.get("workload_kind"),
+                }
+                processes = container.get("processes", []) or []
+                if not processes:
+                    records.append(container_record)
+                    continue
+
+                for process in processes:
+                    if not isinstance(process, dict):
+                        continue
+
+                    pid = process.get("pid")
+                    if not str(pid).isdigit():
+                        continue
+                    records.append(
+                        {
+                            **container_record,
+                            "pid": int(pid),
+                            "process_name": process.get("process_name"),
+                        }
+                    )
+
+        return records
+
+    def _inventory_record_matches_filters(
+        self,
+        record: Dict[str, Any],
+        hostnames: Optional[List[str]] = None,
+        ip_addresses: Optional[List[str]] = None,
+        namespaces: Optional[List[str]] = None,
+        pod_names: Optional[List[str]] = None,
+        container_names: Optional[List[str]] = None,
+        workload_names: Optional[List[str]] = None,
+        process_names: Optional[List[str]] = None,
+        profiling_statuses: Optional[List[str]] = None,
+        command_types: Optional[List[str]] = None,
+        pids: Optional[List[int]] = None,
+    ) -> bool:
+        if not self._matches_any_filter(record.get("hostname"), hostnames):
+            return False
+        if not self._matches_any_filter(record.get("ip_address"), ip_addresses):
+            return False
+        if not self._matches_any_filter(record.get("namespace"), namespaces):
+            return False
+        if not self._matches_any_filter(record.get("pod_name"), pod_names):
+            return False
+        if not self._matches_any_filter(record.get("container_name"), container_names):
+            return False
+        if not self._matches_any_filter(record.get("workload_name"), workload_names):
+            return False
+        if not self._matches_any_filter(record.get("process_name"), process_names):
+            return False
+        if profiling_statuses and not self._matches_any_filter(record.get("profiling_status"), profiling_statuses, exact_match=True):
+            return False
+        if command_types and not self._matches_any_filter(record.get("command_type"), command_types, exact_match=True):
+            return False
+        if pids and record.get("pid") not in pids:
+            return False
+        return True
+
+    def _group_inventory_records(
+        self,
+        scope: str,
+        inventory_records: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        grouped: Dict[Tuple[Any, ...], Dict[str, Any]] = {}
+
+        def ensure_group(key: Tuple[Any, ...], seed: Dict[str, Any]) -> Dict[str, Any]:
+            if key not in grouped:
+                grouped[key] = {
+                    "scope": scope,
+                    "service_name": seed.get("service_name"),
+                    "namespace": seed.get("namespace"),
+                    "hostname": seed.get("hostname"),
+                    "ip_address": seed.get("ip_address"),
+                    "pod_name": seed.get("pod_name"),
+                    "container_name": seed.get("container_name"),
+                    "workload_name": seed.get("workload_name"),
+                    "workload_kind": seed.get("workload_kind"),
+                    "process_name": seed.get("process_name"),
+                    "pid": seed.get("pid"),
+                    "pids": set(),
+                    "hostnames": set(),
+                    "namespaces": set(),
+                    "pods": set(),
+                    "containers": set(),
+                    "processes": set(),
+                    "latest_record": seed,
+                }
+            return grouped[key]
+
+        for record in inventory_records:
+            if scope == "service":
+                key = (record.get("service_name"),)
+            elif scope == "namespace":
+                if record.get("namespace") is None:
+                    continue
+                key = (record.get("service_name"), record.get("namespace"))
+            elif scope == "host":
+                key = (record.get("service_name"), record.get("hostname"))
+            elif scope == "pod":
+                if record.get("pod_name") is None:
+                    continue
+                key = (record.get("service_name"), record.get("namespace"), record.get("pod_name"))
+            elif scope == "container":
+                if record.get("container_name") is None:
+                    continue
+                key = (
+                    record.get("service_name"),
+                    record.get("hostname"),
+                    record.get("namespace"),
+                    record.get("pod_name"),
+                    record.get("container_name"),
+                )
+            else:
+                if record.get("pid") is None:
+                    continue
+                key = (record.get("service_name"), record.get("hostname"), record.get("pid"))
+
+            group = ensure_group(key, record)
+            group["hostnames"].add(record.get("hostname"))
+            if record.get("namespace"):
+                group["namespaces"].add(record.get("namespace"))
+            if record.get("pod_name"):
+                group["pods"].add(record.get("pod_name"))
+            if record.get("container_name"):
+                group["containers"].add(record.get("container_name"))
+            if record.get("pid") is not None:
+                group["processes"].add((record.get("pid"), record.get("process_name")))
+                group["pids"].add(record.get("pid"))
+            if record.get("heartbeat_timestamp") and record["heartbeat_timestamp"] >= group["latest_record"].get("heartbeat_timestamp"):
+                group["latest_record"] = record
+
+        rows: List[Dict[str, Any]] = []
+        for _, group in grouped.items():
+            latest = group["latest_record"]
+            rows.append(
+                {
+                    "id": "|".join("" if value is None else str(value) for value in _),
+                    "scope": scope,
+                    "service_name": latest.get("service_name"),
+                    "namespace": latest.get("namespace"),
+                    "hostname": latest.get("hostname"),
+                    "ip_address": latest.get("ip_address"),
+                    "pod_name": latest.get("pod_name"),
+                    "container_name": latest.get("container_name"),
+                    "workload_name": latest.get("workload_name"),
+                    "workload_kind": latest.get("workload_kind"),
+                    "process_name": latest.get("process_name"),
+                    "pid": latest.get("pid"),
+                    "pids": sorted(group["pids"]),
+                    "active_hosts": len(group["hostnames"]),
+                    "host_count": len(group["hostnames"]),
+                    "namespace_count": len(group["namespaces"]),
+                    "pod_count": len(group["pods"]),
+                    "container_count": len(group["containers"]),
+                    "process_count": len(group["processes"]),
+                    "command_type": latest.get("command_type"),
+                    "profiling_status": latest.get("profiling_status"),
+                    "profiling_mode": latest.get("profiling_mode"),
+                    "frequency": latest.get("frequency"),
+                    "profiler_summary": latest.get("profiler_summary"),
+                    "heartbeat_timestamp": latest.get("heartbeat_timestamp"),
+                    "agent_version": latest.get("agent_version"),
+                    "run_mode": latest.get("run_mode"),
+                }
+            )
+
+        rows.sort(key=lambda row: (row.get("service_name") or "", row.get("namespace") or "", row.get("hostname") or "", row.get("pod_name") or "", row.get("container_name") or "", row.get("pid") or 0))
+        return rows
+
+    def get_workload_inventory_status(
+        self,
+        scope: str,
+        service_names: Optional[List[str]] = None,
+        hostnames: Optional[List[str]] = None,
+        ip_addresses: Optional[List[str]] = None,
+        namespaces: Optional[List[str]] = None,
+        pod_names: Optional[List[str]] = None,
+        container_names: Optional[List[str]] = None,
+        workload_names: Optional[List[str]] = None,
+        process_names: Optional[List[str]] = None,
+        profiling_statuses: Optional[List[str]] = None,
+        command_types: Optional[List[str]] = None,
+        pids: Optional[List[int]] = None,
+        exact_match: bool = False,
+    ) -> Dict[str, Any]:
+        heartbeat_rows = self._get_recent_workload_heartbeat_rows(service_names=service_names, exact_match=exact_match)
+        inventory_records = self._build_inventory_records(heartbeat_rows)
+        filtered_records = [
+            record
+            for record in inventory_records
+            if self._matches_any_filter(record.get("service_name"), service_names, exact_match=exact_match)
+            and self._inventory_record_matches_filters(
+                record,
+                hostnames=hostnames,
+                ip_addresses=ip_addresses,
+                namespaces=namespaces,
+                pod_names=pod_names,
+                container_names=container_names,
+                workload_names=workload_names,
+                process_names=process_names,
+                profiling_statuses=profiling_statuses,
+                command_types=command_types,
+                pids=pids,
+            )
+        ]
+
+        tab_counts = {
+            tab_scope: len(self._group_inventory_records(tab_scope, filtered_records))
+            for tab_scope in ["service", "namespace", "host", "pod", "container", "process"]
+        }
+        rows = self._group_inventory_records(scope, filtered_records)
+        active_hosts = len({row.get("hostname") for row in filtered_records if row.get("hostname")})
+
+        return {
+            "scope": scope,
+            "rows": rows,
+            "tab_counts": tab_counts,
+            "active_hosts": active_hosts,
+            "total_count": len(rows),
+        }
+
+    def resolve_workload_targets(
+        self,
+        service_name: str,
+        target_scope: str,
+        target_entities: Optional[List[Dict[str, Any]]] = None,
+    ) -> Dict[str, Optional[List[int]]]:
+        heartbeat_rows = self._get_recent_workload_heartbeat_rows(service_names=[service_name], exact_match=True)
+        inventory_records = self._build_inventory_records(heartbeat_rows)
+        entities = target_entities or [{"service_name": service_name}]
+        host_pid_mapping: Dict[str, Set[int]] = defaultdict(set)
+        host_only_targets: Set[str] = set()
+
+        for entity in entities:
+            entity_service_name = entity.get("service_name")
+            if entity_service_name and entity_service_name != service_name:
+                continue
+
+            if target_scope in ["service", "host"]:
+                for record in inventory_records:
+                    if target_scope == "service" and record.get("service_name") == service_name:
+                        host_only_targets.add(record["hostname"])
+                    elif target_scope == "host" and record.get("hostname") == entity.get("hostname"):
+                        host_only_targets.add(record["hostname"])
+                continue
+
+            for record in inventory_records:
+                hostname = record.get("hostname")
+                pid = record.get("pid")
+                if hostname is None or pid is None:
+                    continue
+
+                matches = False
+                if target_scope == "namespace":
+                    matches = record.get("namespace") == entity.get("namespace")
+                elif target_scope == "workload":
+                    matches = (
+                        record.get("workload_name") == entity.get("workload_name")
+                        and (entity.get("namespace") is None or record.get("namespace") == entity.get("namespace"))
+                    )
+                elif target_scope == "pod":
+                    matches = (
+                        record.get("pod_name") == entity.get("pod_name")
+                        and (entity.get("namespace") is None or record.get("namespace") == entity.get("namespace"))
+                    )
+                elif target_scope == "container":
+                    matches = (
+                        record.get("container_name") == entity.get("container_name")
+                        and (entity.get("pod_name") is None or record.get("pod_name") == entity.get("pod_name"))
+                        and (entity.get("namespace") is None or record.get("namespace") == entity.get("namespace"))
+                    )
+                elif target_scope == "process":
+                    matches = (
+                        (entity.get("pid") is not None and pid == entity.get("pid"))
+                        or (
+                            entity.get("process_name") is not None
+                            and record.get("process_name") == entity.get("process_name")
+                            and (entity.get("container_name") is None or record.get("container_name") == entity.get("container_name"))
+                            and (entity.get("pod_name") is None or record.get("pod_name") == entity.get("pod_name"))
+                            and (entity.get("namespace") is None or record.get("namespace") == entity.get("namespace"))
+                        )
+                    )
+
+                if matches:
+                    host_pid_mapping[hostname].add(pid)
+
+        resolved_targets: Dict[str, Optional[List[int]]] = {hostname: None for hostname in sorted(host_only_targets)}
+        for hostname, pid_set in host_pid_mapping.items():
+            resolved_targets[hostname] = sorted(pid_set)
+        return resolved_targets
 
     def get_profiling_host_status_optimized(
         self,

--- a/src/gprofiler-dev/gprofiler_dev/postgres/db_manager.py
+++ b/src/gprofiler-dev/gprofiler_dev/postgres/db_manager.py
@@ -18,6 +18,7 @@ import hashlib
 import json
 import threading
 import time
+import uuid
 from collections import defaultdict
 from datetime import datetime, timedelta
 from secrets import token_urlsafe
@@ -1375,6 +1376,78 @@ class DBManager(metaclass=Singleton):
 
         self.db.execute(upsert_query, values, has_value=False)
         return True
+
+    def get_active_service_subscription(self, service_name: str) -> Optional[str]:
+        """Return the request_id of the active service-wide profiling subscription
+        for a service, or None.
+
+        A service is "actively subscribed" when its most recent service-scoped
+        continuous "start" request is newer than any service-scoped "stop" request
+        (and was not cancelled). This is what lets hosts that register *after* a
+        service-wide profiling request auto-join the in-progress profile.
+        """
+        start_query = """
+        SELECT request_id, created_at
+        FROM ProfilingRequests
+        WHERE service_name = %(service_name)s
+          AND request_type = 'start'
+          AND continuous = TRUE
+          AND COALESCE(additional_args->>'target_scope', 'host') = 'service'
+          AND status != 'cancelled'
+        ORDER BY created_at DESC
+        LIMIT 1
+        """
+        start_row = self.db.execute(
+            start_query, {"service_name": service_name}, one_value=True, return_dict=True
+        )
+        if not start_row:
+            return None
+
+        stop_query = """
+        SELECT created_at
+        FROM ProfilingRequests
+        WHERE service_name = %(service_name)s
+          AND request_type = 'stop'
+          AND COALESCE(additional_args->>'target_scope', 'host') = 'service'
+        ORDER BY created_at DESC
+        LIMIT 1
+        """
+        stop_row = self.db.execute(
+            stop_query, {"service_name": service_name}, one_value=True, return_dict=True
+        )
+        if stop_row and stop_row["created_at"] >= start_row["created_at"]:
+            return None
+
+        return str(start_row["request_id"])
+
+    def auto_subscribe_host_to_service(self, hostname: str, service_name: str) -> bool:
+        """Enroll a host into its service's active service-wide profiling.
+
+        Invoked on every heartbeat. When a service has an active service-wide
+        profiling subscription and the reporting host has no current command
+        (e.g. a node that was just added to the cluster by autoscaling), a start
+        command is created for it from the subscription's configuration. Hosts
+        that already have command state are left untouched so explicit per-host
+        actions (including stops) are preserved.
+
+        Returns True if a new subscription command was created for the host.
+        """
+        subscription_request_id = self.get_active_service_subscription(service_name)
+        if not subscription_request_id:
+            return False
+
+        current_command = self.get_current_profiling_command(hostname, service_name)
+        if current_command is not None:
+            return False
+
+        command_id = str(uuid.uuid4())
+        return self.create_or_update_profiling_command(
+            command_id=command_id,
+            hostname=hostname,
+            service_name=service_name,
+            command_type="start",
+            new_request_id=subscription_request_id,
+        )
 
     def _merge_profiling_configs(self, existing_config: Dict, new_config: Dict) -> Dict:
         """Merge two profiling configurations, combining parameters appropriately"""

--- a/src/gprofiler-dev/gprofiler_dev/postgres/db_manager.py
+++ b/src/gprofiler-dev/gprofiler_dev/postgres/db_manager.py
@@ -1907,7 +1907,24 @@ class DBManager(metaclass=Singleton):
                 c.combined_config AS combined_config,
                 CASE
                     WHEN c.status IS NULL THEN 'stopped'
-                    WHEN c.command_type = 'start' AND c.status IN ('pending', 'sent', 'completed') THEN 'active'
+                    WHEN c.command_type = 'start' AND c.status IN ('pending', 'sent', 'completed') THEN
+                        -- PID-aware: an active "start" command may target only a subset of
+                        -- PIDs on the host (e.g. a single container/pod). A row is only
+                        -- "active" when the command targets all PIDs on the host (no/empty
+                        -- "pids" list == whole host) OR this row's PID is in the target set.
+                        CASE
+                            WHEN c.combined_config IS NULL
+                                 OR (c.combined_config -> 'pids') IS NULL
+                                 OR jsonb_typeof(c.combined_config -> 'pids') <> 'array'
+                                 OR jsonb_array_length(c.combined_config -> 'pids') = 0
+                                THEN 'active'
+                            WHEN hp.pid IS NOT NULL AND EXISTS (
+                                SELECT 1
+                                FROM jsonb_array_elements_text(c.combined_config -> 'pids') AS target(pid)
+                                WHERE target.pid = hp.pid::text
+                            ) THEN 'active'
+                            ELSE 'stopped'
+                        END
                     ELSE c.status::text
                 END AS profiling_status
             FROM HostHeartbeats h
@@ -1951,6 +1968,8 @@ class DBManager(metaclass=Singleton):
             (array_agg(command_type ORDER BY heartbeat_timestamp DESC NULLS LAST))[1] AS l_command_type,
             (array_agg(command_status ORDER BY heartbeat_timestamp DESC NULLS LAST))[1] AS l_command_status,
             (array_agg(combined_config ORDER BY heartbeat_timestamp DESC NULLS LAST))[1] AS l_combined_config,
+            bool_or(profiling_status = 'active') AS any_active,
+            (array_agg(profiling_status ORDER BY heartbeat_timestamp DESC NULLS LAST))[1] AS l_profiling_status,
             (array_agg(agent_version ORDER BY heartbeat_timestamp DESC NULLS LAST))[1] AS l_agent_version,
             (array_agg(run_mode ORDER BY heartbeat_timestamp DESC NULLS LAST))[1] AS l_run_mode,
             MAX(heartbeat_timestamp) AS l_heartbeat_timestamp
@@ -1969,6 +1988,16 @@ class DBManager(metaclass=Singleton):
                 db_row.get("l_command_type"),
                 db_row.get("l_command_status"),
             )
+            # Prefer the PID-aware, row-level status computed in SQL over the host-level
+            # command status. A group is "active" when any of its rows are actively
+            # targeted (whole-host command or a matching PID); otherwise fall back to the
+            # latest row status so entities on a host that is only partially profiled
+            # (e.g. one container) are not incorrectly shown as active.
+            profiling_status = (
+                "active" if db_row.get("any_active") else db_row.get("l_profiling_status")
+            )
+            if not profiling_status:
+                profiling_status = command_metadata.get("profiling_status")
             host_count = db_row.get("host_count") or 0
             rows.append(
                 {
@@ -1992,7 +2021,7 @@ class DBManager(metaclass=Singleton):
                     "container_count": db_row.get("container_count") or 0,
                     "process_count": db_row.get("process_count") or 0,
                     "command_type": command_metadata.get("command_type"),
-                    "profiling_status": command_metadata.get("profiling_status"),
+                    "profiling_status": profiling_status,
                     "profiling_mode": command_metadata.get("profiling_mode"),
                     "frequency": command_metadata.get("frequency"),
                     "profiler_summary": command_metadata.get("profiler_summary"),

--- a/src/gprofiler-dev/gprofiler_dev/postgres/db_manager.py
+++ b/src/gprofiler-dev/gprofiler_dev/postgres/db_manager.py
@@ -1726,23 +1726,6 @@ class DBManager(metaclass=Singleton):
         return value
 
     @staticmethod
-    def _matches_any_filter(value: Optional[Any], filters: Optional[List[Any]], exact_match: bool = False) -> bool:
-        if not filters:
-            return True
-        if value is None:
-            return False
-
-        value_str = str(value).lower()
-        for raw_filter in filters:
-            filter_str = str(raw_filter).lower()
-            if exact_match:
-                if value_str == filter_str:
-                    return True
-            elif filter_str in value_str:
-                return True
-        return False
-
-    @staticmethod
     def _normalize_profiling_status(command_type: Optional[str], command_status: Optional[str]) -> str:
         if command_status is None:
             return "stopped"
@@ -1796,12 +1779,99 @@ class DBManager(metaclass=Singleton):
             "profiling_status": self._normalize_profiling_status(command_type, command_status),
         }
 
-    def _get_recent_workload_heartbeat_rows(
+    # Group keys per scope; the first element is always the grouping granularity and is
+    # also used to build the stable row "id". Scopes that key on an optional column skip
+    # records where that column is NULL (matching the previous Python behavior).
+    _WORKLOAD_SCOPE_KEYS: Dict[str, List[str]] = {
+        "service": ["service_name"],
+        "namespace": ["service_name", "namespace"],
+        "host": ["service_name", "hostname"],
+        "pod": ["service_name", "namespace", "pod_name"],
+        "container": ["service_name", "hostname", "namespace", "pod_name", "container_name"],
+        "process": ["service_name", "hostname", "pid"],
+    }
+    _WORKLOAD_SCOPE_NULL_GUARD: Dict[str, str] = {
+        "namespace": "namespace IS NOT NULL",
+        "pod": "pod_name IS NOT NULL",
+        "container": "container_name IS NOT NULL",
+        "process": "pid IS NOT NULL",
+    }
+
+    def _workload_inventory_cte(
         self,
-        service_names: Optional[List[str]] = None,
-        exact_match: bool = False,
-    ) -> List[Dict[str, Any]]:
-        query = """
+        service_names: Optional[List[str]],
+        exact_match: bool,
+        hostnames: Optional[List[str]],
+        ip_addresses: Optional[List[str]],
+        namespaces: Optional[List[str]],
+        pod_names: Optional[List[str]],
+        container_names: Optional[List[str]],
+        workload_names: Optional[List[str]],
+        process_names: Optional[List[str]],
+        profiling_statuses: Optional[List[str]],
+        command_types: Optional[List[str]],
+        pids: Optional[List[int]],
+    ) -> Tuple[str, Dict[str, Any]]:
+        """Build the shared ``WITH ... filtered AS (...)`` CTE for workload inventory.
+
+        The flattened CTE joins HostHeartbeats to the latest per-host command and to the
+        normalized container/process tables, so a host with no containers contributes one
+        row (NULL container/process columns) and every (container, process) pair is one
+        row. All caller-supplied filters are applied inside ``filtered`` so both the
+        tab-count and grouped-row queries operate on the same filtered set.
+        """
+        params: Dict[str, Any] = {}
+        conditions: List[str] = []
+
+        def add_partial(column: str, values: Optional[List[Any]], prefix: str) -> None:
+            if not values:
+                return
+            ors = []
+            for idx, value in enumerate(values):
+                key = f"{prefix}_{idx}"
+                ors.append(f"{column}::text ILIKE %({key})s")
+                params[key] = f"%{value}%"
+            conditions.append("(" + " OR ".join(ors) + ")")
+
+        def add_exact(column: str, values: Optional[List[Any]], prefix: str) -> None:
+            if not values:
+                return
+            ors = []
+            for idx, value in enumerate(values):
+                key = f"{prefix}_{idx}"
+                ors.append(f"LOWER({column}::text) = LOWER(%({key})s)")
+                params[key] = str(value)
+            conditions.append("(" + " OR ".join(ors) + ")")
+
+        service_filter = "TRUE"
+        if service_names:
+            if exact_match:
+                service_filter = "h.service_name = ANY(%(service_names)s)"
+                params["service_names"] = service_names
+            else:
+                ors = []
+                for idx, service_name in enumerate(service_names):
+                    key = f"svc_{idx}"
+                    ors.append(f"h.service_name ILIKE %({key})s")
+                    params[key] = f"%{service_name}%"
+                service_filter = "(" + " OR ".join(ors) + ")"
+
+        add_partial("hostname", hostnames, "host")
+        add_partial("ip_address", ip_addresses, "ip")
+        add_partial("namespace", namespaces, "ns")
+        add_partial("pod_name", pod_names, "pod")
+        add_partial("container_name", container_names, "cont")
+        add_partial("workload_name", workload_names, "wl")
+        add_partial("process_name", process_names, "proc")
+        add_exact("profiling_status", profiling_statuses, "pstat")
+        add_exact("command_type", command_types, "ctype")
+        if pids:
+            conditions.append("pid = ANY(%(pids)s)")
+            params["pids"] = pids
+
+        filter_where = " AND ".join(conditions) if conditions else "TRUE"
+
+        cte = f"""
         WITH latest_commands AS (
             SELECT
                 pc.hostname,
@@ -1809,300 +1879,139 @@ class DBManager(metaclass=Singleton):
                 pc.command_type,
                 pc.status,
                 pc.combined_config,
-                pc.created_at,
-                ROW_NUMBER() OVER (PARTITION BY pc.hostname, pc.service_name ORDER BY pc.created_at DESC) as rn
+                ROW_NUMBER() OVER (PARTITION BY pc.hostname, pc.service_name ORDER BY pc.created_at DESC) AS rn
             FROM ProfilingCommands pc
         ),
         current_commands AS (
-            SELECT
-                hostname,
-                service_name,
-                command_type,
-                status,
-                combined_config
+            SELECT hostname, service_name, command_type, status, combined_config
             FROM latest_commands
             WHERE rn = 1
+        ),
+        flattened AS (
+            SELECT
+                h.hostname,
+                host(h.ip_address) AS ip_address,
+                h.service_name,
+                h.agent_version,
+                h.run_mode,
+                h.heartbeat_timestamp,
+                hc.container_name,
+                hc.namespace,
+                hc.pod_name,
+                hc.workload_name,
+                hc.workload_kind,
+                hp.pid,
+                hp.process_name,
+                COALESCE(c.command_type, 'N/A') AS command_type,
+                c.status AS command_status,
+                c.combined_config AS combined_config,
+                CASE
+                    WHEN c.status IS NULL THEN 'stopped'
+                    WHEN c.command_type = 'start' AND c.status IN ('pending', 'sent', 'completed') THEN 'active'
+                    ELSE c.status::text
+                END AS profiling_status
+            FROM HostHeartbeats h
+            LEFT JOIN current_commands c
+                ON h.hostname = c.hostname AND h.service_name = c.service_name
+            LEFT JOIN HeartbeatContainers hc ON hc.host_id = h.id
+            LEFT JOIN HeartbeatProcesses hp ON hp.container_row_id = hc.id
+            WHERE h.heartbeat_timestamp > NOW() - INTERVAL '2 minutes'
+              AND {service_filter}
+        ),
+        filtered AS (
+            SELECT * FROM flattened WHERE {filter_where}
         )
+        """
+        return cte, params
+
+    def _query_workload_groups(self, scope: str, cte: str, params: Dict[str, Any]) -> List[Dict[str, Any]]:
+        key_cols = self._WORKLOAD_SCOPE_KEYS.get(scope, self._WORKLOAD_SCOPE_KEYS["process"])
+        guard = self._WORKLOAD_SCOPE_NULL_GUARD.get(scope)
+        where_clause = f"WHERE {guard}" if guard else ""
+        group_by = ", ".join(key_cols)
+
+        query = cte + f"""
         SELECT
-            h.id,
-            h.hostname,
-            h.ip_address,
-            h.service_name,
-            h.agent_version,
-            h.run_mode,
-            h.namespace,
-            h.pod_name,
-            h.heartbeat_timestamp,
-            c.command_type,
-            c.status,
-            c.combined_config
-        FROM HostHeartbeats h
-        LEFT JOIN current_commands c
-            ON h.hostname = c.hostname AND h.service_name = c.service_name
-        WHERE h.heartbeat_timestamp > NOW() - INTERVAL '2 minutes'
+            {group_by},
+            COUNT(DISTINCT hostname) AS host_count,
+            COUNT(DISTINCT namespace) FILTER (WHERE namespace IS NOT NULL) AS namespace_count,
+            COUNT(DISTINCT pod_name) FILTER (WHERE pod_name IS NOT NULL) AS pod_count,
+            COUNT(DISTINCT container_name) FILTER (WHERE container_name IS NOT NULL) AS container_count,
+            COUNT(DISTINCT (pid, process_name)) FILTER (WHERE pid IS NOT NULL) AS process_count,
+            array_agg(DISTINCT pid) FILTER (WHERE pid IS NOT NULL) AS pids,
+            (array_agg(hostname ORDER BY heartbeat_timestamp DESC NULLS LAST))[1] AS l_hostname,
+            (array_agg(ip_address ORDER BY heartbeat_timestamp DESC NULLS LAST))[1] AS l_ip_address,
+            (array_agg(namespace ORDER BY heartbeat_timestamp DESC NULLS LAST))[1] AS l_namespace,
+            (array_agg(pod_name ORDER BY heartbeat_timestamp DESC NULLS LAST))[1] AS l_pod_name,
+            (array_agg(container_name ORDER BY heartbeat_timestamp DESC NULLS LAST))[1] AS l_container_name,
+            (array_agg(workload_name ORDER BY heartbeat_timestamp DESC NULLS LAST))[1] AS l_workload_name,
+            (array_agg(workload_kind ORDER BY heartbeat_timestamp DESC NULLS LAST))[1] AS l_workload_kind,
+            (array_agg(process_name ORDER BY heartbeat_timestamp DESC NULLS LAST))[1] AS l_process_name,
+            (array_agg(pid ORDER BY heartbeat_timestamp DESC NULLS LAST))[1] AS l_pid,
+            (array_agg(command_type ORDER BY heartbeat_timestamp DESC NULLS LAST))[1] AS l_command_type,
+            (array_agg(command_status ORDER BY heartbeat_timestamp DESC NULLS LAST))[1] AS l_command_status,
+            (array_agg(combined_config ORDER BY heartbeat_timestamp DESC NULLS LAST))[1] AS l_combined_config,
+            (array_agg(agent_version ORDER BY heartbeat_timestamp DESC NULLS LAST))[1] AS l_agent_version,
+            (array_agg(run_mode ORDER BY heartbeat_timestamp DESC NULLS LAST))[1] AS l_run_mode,
+            MAX(heartbeat_timestamp) AS l_heartbeat_timestamp
+        FROM filtered
+        {where_clause}
+        GROUP BY {group_by}
         """
 
-        values: Dict[str, Any] = {}
-        if service_names:
-            if exact_match:
-                query += " AND h.service_name = ANY(%(service_names)s)"
-                values["service_names"] = service_names
-            else:
-                service_conditions = []
-                for idx, service_name in enumerate(service_names):
-                    param_name = f"service_name_{idx}"
-                    service_conditions.append(f"h.service_name ILIKE %({param_name})s")
-                    values[param_name] = f"%{service_name}%"
-                query += f" AND ({' OR '.join(service_conditions)})"
-
-        query += " ORDER BY h.heartbeat_timestamp DESC"
-        return self.db.execute(query, values, one_value=False, return_dict=True, fetch_all=True)
-
-    def _get_structured_inventory_by_host(self, host_ids: List[int]) -> Dict[int, List[Dict[str, Any]]]:
-        """Fetch the normalized container/process inventory for the given host rows.
-
-        Returns a map of host_id -> flattened rows. Each row is one (container, process)
-        pair; a container with no processes yields a single row with a NULL pid. This
-        mirrors the shape produced by flattening the JSONB snapshot, so callers can use
-        either source interchangeably.
-        """
-        if not host_ids:
-            return {}
-
-        query = """
-        SELECT
-            hc.host_id,
-            hc.container_id,
-            hc.container_name,
-            hc.namespace,
-            hc.pod_name,
-            hc.workload_name,
-            hc.workload_kind,
-            hp.pid,
-            hp.process_name
-        FROM HeartbeatContainers hc
-        LEFT JOIN HeartbeatProcesses hp ON hp.container_row_id = hc.id
-        WHERE hc.host_id = ANY(%(host_ids)s)
-        ORDER BY hc.id, hp.pid
-        """
-        rows = self.db.execute(
-            query, {"host_ids": host_ids}, one_value=False, return_dict=True, fetch_all=True
-        )
-
-        grouped: Dict[int, List[Dict[str, Any]]] = defaultdict(list)
-        for row in rows or []:
-            grouped[row["host_id"]].append(row)
-        return grouped
-
-    def _build_inventory_records(self, heartbeat_rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        records: List[Dict[str, Any]] = []
-
-        host_ids = [row.get("id") for row in heartbeat_rows if row.get("id") is not None]
-        structured_by_host = self._get_structured_inventory_by_host(host_ids)
-
-        for row in heartbeat_rows:
-            command_metadata = self._extract_command_metadata(
-                row.get("combined_config"),
-                row.get("command_type"),
-                row.get("status"),
-            )
-            base_record = {
-                "host_id": row.get("id"),
-                "hostname": row.get("hostname"),
-                "ip_address": row.get("ip_address"),
-                "service_name": row.get("service_name"),
-                "agent_version": row.get("agent_version"),
-                "run_mode": row.get("run_mode"),
-                "agent_namespace": row.get("namespace"),
-                "agent_pod_name": row.get("pod_name"),
-                "heartbeat_timestamp": row.get("heartbeat_timestamp"),
-                **command_metadata,
-            }
-
-            # Inventory comes from the normalized HeartbeatContainers/HeartbeatProcesses
-            # tables. Hosts with no container inventory (plain hosts, or workloads that
-            # report none) contribute a single host-level record.
-            structured_rows = structured_by_host.get(row.get("id"))
-            if structured_rows:
-                records.extend(self._records_from_structured(base_record, structured_rows))
-            else:
-                records.append(base_record.copy())
-
-        return records
-
-    @staticmethod
-    def _records_from_structured(
-        base_record: Dict[str, Any], structured_rows: List[Dict[str, Any]]
-    ) -> List[Dict[str, Any]]:
-        records: List[Dict[str, Any]] = []
-        for srow in structured_rows:
-            container_record = {
-                **base_record,
-                "container_id": srow.get("container_id"),
-                "container_name": srow.get("container_name"),
-                "namespace": srow.get("namespace"),
-                "pod_name": srow.get("pod_name"),
-                "workload_name": srow.get("workload_name"),
-                "workload_kind": srow.get("workload_kind"),
-            }
-            pid = srow.get("pid")
-            if pid is None:
-                records.append(container_record)
-            else:
-                records.append(
-                    {
-                        **container_record,
-                        "pid": int(pid),
-                        "process_name": srow.get("process_name"),
-                    }
-                )
-        return records
-
-    def _inventory_record_matches_filters(
-        self,
-        record: Dict[str, Any],
-        hostnames: Optional[List[str]] = None,
-        ip_addresses: Optional[List[str]] = None,
-        namespaces: Optional[List[str]] = None,
-        pod_names: Optional[List[str]] = None,
-        container_names: Optional[List[str]] = None,
-        workload_names: Optional[List[str]] = None,
-        process_names: Optional[List[str]] = None,
-        profiling_statuses: Optional[List[str]] = None,
-        command_types: Optional[List[str]] = None,
-        pids: Optional[List[int]] = None,
-    ) -> bool:
-        if not self._matches_any_filter(record.get("hostname"), hostnames):
-            return False
-        if not self._matches_any_filter(record.get("ip_address"), ip_addresses):
-            return False
-        if not self._matches_any_filter(record.get("namespace"), namespaces):
-            return False
-        if not self._matches_any_filter(record.get("pod_name"), pod_names):
-            return False
-        if not self._matches_any_filter(record.get("container_name"), container_names):
-            return False
-        if not self._matches_any_filter(record.get("workload_name"), workload_names):
-            return False
-        if not self._matches_any_filter(record.get("process_name"), process_names):
-            return False
-        if profiling_statuses and not self._matches_any_filter(record.get("profiling_status"), profiling_statuses, exact_match=True):
-            return False
-        if command_types and not self._matches_any_filter(record.get("command_type"), command_types, exact_match=True):
-            return False
-        if pids and record.get("pid") not in pids:
-            return False
-        return True
-
-    def _group_inventory_records(
-        self,
-        scope: str,
-        inventory_records: List[Dict[str, Any]],
-    ) -> List[Dict[str, Any]]:
-        grouped: Dict[Tuple[Any, ...], Dict[str, Any]] = {}
-
-        def ensure_group(key: Tuple[Any, ...], seed: Dict[str, Any]) -> Dict[str, Any]:
-            if key not in grouped:
-                grouped[key] = {
-                    "scope": scope,
-                    "service_name": seed.get("service_name"),
-                    "namespace": seed.get("namespace"),
-                    "hostname": seed.get("hostname"),
-                    "ip_address": seed.get("ip_address"),
-                    "pod_name": seed.get("pod_name"),
-                    "container_name": seed.get("container_name"),
-                    "workload_name": seed.get("workload_name"),
-                    "workload_kind": seed.get("workload_kind"),
-                    "process_name": seed.get("process_name"),
-                    "pid": seed.get("pid"),
-                    "pids": set(),
-                    "hostnames": set(),
-                    "namespaces": set(),
-                    "pods": set(),
-                    "containers": set(),
-                    "processes": set(),
-                    "latest_record": seed,
-                }
-            return grouped[key]
-
-        for record in inventory_records:
-            if scope == "service":
-                key = (record.get("service_name"),)
-            elif scope == "namespace":
-                if record.get("namespace") is None:
-                    continue
-                key = (record.get("service_name"), record.get("namespace"))
-            elif scope == "host":
-                key = (record.get("service_name"), record.get("hostname"))
-            elif scope == "pod":
-                if record.get("pod_name") is None:
-                    continue
-                key = (record.get("service_name"), record.get("namespace"), record.get("pod_name"))
-            elif scope == "container":
-                if record.get("container_name") is None:
-                    continue
-                key = (
-                    record.get("service_name"),
-                    record.get("hostname"),
-                    record.get("namespace"),
-                    record.get("pod_name"),
-                    record.get("container_name"),
-                )
-            else:
-                if record.get("pid") is None:
-                    continue
-                key = (record.get("service_name"), record.get("hostname"), record.get("pid"))
-
-            group = ensure_group(key, record)
-            group["hostnames"].add(record.get("hostname"))
-            if record.get("namespace"):
-                group["namespaces"].add(record.get("namespace"))
-            if record.get("pod_name"):
-                group["pods"].add(record.get("pod_name"))
-            if record.get("container_name"):
-                group["containers"].add(record.get("container_name"))
-            if record.get("pid") is not None:
-                group["processes"].add((record.get("pid"), record.get("process_name")))
-                group["pids"].add(record.get("pid"))
-            if record.get("heartbeat_timestamp") and record["heartbeat_timestamp"] >= group["latest_record"].get("heartbeat_timestamp"):
-                group["latest_record"] = record
-
+        db_rows = self.db.execute(query, params, one_value=False, return_dict=True, fetch_all=True)
         rows: List[Dict[str, Any]] = []
-        for _, group in grouped.items():
-            latest = group["latest_record"]
+        for db_row in db_rows or []:
+            key_values = [db_row.get(col) for col in key_cols]
+            row_id = "|".join("" if value is None else str(value) for value in key_values)
+            command_metadata = self._extract_command_metadata(
+                db_row.get("l_combined_config"),
+                db_row.get("l_command_type"),
+                db_row.get("l_command_status"),
+            )
+            host_count = db_row.get("host_count") or 0
             rows.append(
                 {
-                    "id": "|".join("" if value is None else str(value) for value in _),
+                    "id": row_id,
                     "scope": scope,
-                    "service_name": latest.get("service_name"),
-                    "namespace": latest.get("namespace"),
-                    "hostname": latest.get("hostname"),
-                    "ip_address": latest.get("ip_address"),
-                    "pod_name": latest.get("pod_name"),
-                    "container_name": latest.get("container_name"),
-                    "workload_name": latest.get("workload_name"),
-                    "workload_kind": latest.get("workload_kind"),
-                    "process_name": latest.get("process_name"),
-                    "pid": latest.get("pid"),
-                    "pids": sorted(group["pids"]),
-                    "active_hosts": len(group["hostnames"]),
-                    "host_count": len(group["hostnames"]),
-                    "namespace_count": len(group["namespaces"]),
-                    "pod_count": len(group["pods"]),
-                    "container_count": len(group["containers"]),
-                    "process_count": len(group["processes"]),
-                    "command_type": latest.get("command_type"),
-                    "profiling_status": latest.get("profiling_status"),
-                    "profiling_mode": latest.get("profiling_mode"),
-                    "frequency": latest.get("frequency"),
-                    "profiler_summary": latest.get("profiler_summary"),
-                    "heartbeat_timestamp": latest.get("heartbeat_timestamp"),
-                    "agent_version": latest.get("agent_version"),
-                    "run_mode": latest.get("run_mode"),
+                    "service_name": db_row.get("service_name"),
+                    "namespace": db_row.get("l_namespace"),
+                    "hostname": db_row.get("l_hostname"),
+                    "ip_address": db_row.get("l_ip_address"),
+                    "pod_name": db_row.get("l_pod_name"),
+                    "container_name": db_row.get("l_container_name"),
+                    "workload_name": db_row.get("l_workload_name"),
+                    "workload_kind": db_row.get("l_workload_kind"),
+                    "process_name": db_row.get("l_process_name"),
+                    "pid": db_row.get("l_pid"),
+                    "pids": sorted(db_row.get("pids") or []),
+                    "active_hosts": host_count,
+                    "host_count": host_count,
+                    "namespace_count": db_row.get("namespace_count") or 0,
+                    "pod_count": db_row.get("pod_count") or 0,
+                    "container_count": db_row.get("container_count") or 0,
+                    "process_count": db_row.get("process_count") or 0,
+                    "command_type": command_metadata.get("command_type"),
+                    "profiling_status": command_metadata.get("profiling_status"),
+                    "profiling_mode": command_metadata.get("profiling_mode"),
+                    "frequency": command_metadata.get("frequency"),
+                    "profiler_summary": command_metadata.get("profiler_summary"),
+                    "heartbeat_timestamp": db_row.get("l_heartbeat_timestamp"),
+                    "agent_version": db_row.get("l_agent_version"),
+                    "run_mode": db_row.get("l_run_mode"),
                 }
             )
 
-        rows.sort(key=lambda row: (row.get("service_name") or "", row.get("namespace") or "", row.get("hostname") or "", row.get("pod_name") or "", row.get("container_name") or "", row.get("pid") or 0))
+        rows.sort(
+            key=lambda row: (
+                row.get("service_name") or "",
+                row.get("namespace") or "",
+                row.get("hostname") or "",
+                row.get("pod_name") or "",
+                row.get("container_name") or "",
+                row.get("pid") or 0,
+            )
+        )
         return rows
 
     def get_workload_inventory_status(
@@ -2121,33 +2030,46 @@ class DBManager(metaclass=Singleton):
         pids: Optional[List[int]] = None,
         exact_match: bool = False,
     ) -> Dict[str, Any]:
-        heartbeat_rows = self._get_recent_workload_heartbeat_rows(service_names=service_names, exact_match=exact_match)
-        inventory_records = self._build_inventory_records(heartbeat_rows)
-        filtered_records = [
-            record
-            for record in inventory_records
-            if self._matches_any_filter(record.get("service_name"), service_names, exact_match=exact_match)
-            and self._inventory_record_matches_filters(
-                record,
-                hostnames=hostnames,
-                ip_addresses=ip_addresses,
-                namespaces=namespaces,
-                pod_names=pod_names,
-                container_names=container_names,
-                workload_names=workload_names,
-                process_names=process_names,
-                profiling_statuses=profiling_statuses,
-                command_types=command_types,
-                pids=pids,
-            )
-        ]
+        cte, params = self._workload_inventory_cte(
+            service_names=service_names,
+            exact_match=exact_match,
+            hostnames=hostnames,
+            ip_addresses=ip_addresses,
+            namespaces=namespaces,
+            pod_names=pod_names,
+            container_names=container_names,
+            workload_names=workload_names,
+            process_names=process_names,
+            profiling_statuses=profiling_statuses,
+            command_types=command_types,
+            pids=pids,
+        )
 
+        # Tab counts and active-host total in a single pass over the filtered set.
+        tab_query = cte + """
+        SELECT
+            COUNT(DISTINCT service_name) AS c_service,
+            COUNT(DISTINCT (service_name, namespace)) FILTER (WHERE namespace IS NOT NULL) AS c_namespace,
+            COUNT(DISTINCT (service_name, hostname)) AS c_host,
+            COUNT(DISTINCT (service_name, namespace, pod_name)) FILTER (WHERE pod_name IS NOT NULL) AS c_pod,
+            COUNT(DISTINCT (service_name, hostname, namespace, pod_name, container_name)) FILTER (WHERE container_name IS NOT NULL) AS c_container,
+            COUNT(DISTINCT (service_name, hostname, pid)) FILTER (WHERE pid IS NOT NULL) AS c_process,
+            COUNT(DISTINCT hostname) FILTER (WHERE hostname IS NOT NULL) AS active_hosts
+        FROM filtered
+        """
+        tab_rows = self.db.execute(tab_query, params, one_value=False, return_dict=True, fetch_all=True)
+        counts = (tab_rows or [{}])[0] or {}
         tab_counts = {
-            tab_scope: len(self._group_inventory_records(tab_scope, filtered_records))
-            for tab_scope in ["service", "namespace", "host", "pod", "container", "process"]
+            "service": counts.get("c_service") or 0,
+            "namespace": counts.get("c_namespace") or 0,
+            "host": counts.get("c_host") or 0,
+            "pod": counts.get("c_pod") or 0,
+            "container": counts.get("c_container") or 0,
+            "process": counts.get("c_process") or 0,
         }
-        rows = self._group_inventory_records(scope, filtered_records)
-        active_hosts = len({row.get("hostname") for row in filtered_records if row.get("hostname")})
+        active_hosts = counts.get("active_hosts") or 0
+
+        rows = self._query_workload_groups(scope, cte, params)
 
         return {
             "scope": scope,
@@ -2163,69 +2085,114 @@ class DBManager(metaclass=Singleton):
         target_scope: str,
         target_entities: Optional[List[Dict[str, Any]]] = None,
     ) -> Dict[str, Optional[List[int]]]:
-        heartbeat_rows = self._get_recent_workload_heartbeat_rows(service_names=[service_name], exact_match=True)
-        inventory_records = self._build_inventory_records(heartbeat_rows)
+        """Resolve workload selectors into concrete host/PID profiling targets.
+
+        Matching is pushed down to SQL joins over HostHeartbeats / HeartbeatContainers /
+        HeartbeatProcesses so we never materialize the full inventory in Python.
+        Service- and host-scope resolve to host-level targets (PID list = None); the
+        finer scopes resolve to per-host PID sets.
+        """
         entities = target_entities or [{"service_name": service_name}]
+        recency = "h.heartbeat_timestamp > NOW() - INTERVAL '2 minutes'"
+
+        if target_scope in ("service", "host"):
+            query = (
+                f"SELECT DISTINCT h.hostname FROM HostHeartbeats h "
+                f"WHERE {recency} AND h.service_name = %(service_name)s"
+            )
+            params: Dict[str, Any] = {"service_name": service_name}
+            if target_scope == "host":
+                wanted_hosts = sorted(
+                    {
+                        entity.get("hostname")
+                        for entity in entities
+                        if entity.get("hostname")
+                        and (not entity.get("service_name") or entity.get("service_name") == service_name)
+                    }
+                )
+                if not wanted_hosts:
+                    return {}
+                query += " AND h.hostname = ANY(%(wanted_hosts)s)"
+                params["wanted_hosts"] = wanted_hosts
+
+            rows = self.db.execute(query, params, one_value=False, return_dict=True, fetch_all=True)
+            hostnames = sorted({row["hostname"] for row in (rows or []) if row.get("hostname")})
+            return {hostname: None for hostname in hostnames}
+
+        # Finer scopes require a concrete process, so inner-join through to processes.
+        base_from = (
+            "FROM HostHeartbeats h "
+            "JOIN HeartbeatContainers hc ON hc.host_id = h.id "
+            "JOIN HeartbeatProcesses hp ON hp.container_row_id = hc.id "
+            f"WHERE {recency} AND h.service_name = %(service_name)s"
+        )
+
         host_pid_mapping: Dict[str, Set[int]] = defaultdict(set)
-        host_only_targets: Set[str] = set()
-
         for entity in entities:
-            entity_service_name = entity.get("service_name")
-            if entity_service_name and entity_service_name != service_name:
+            if entity.get("service_name") and entity.get("service_name") != service_name:
                 continue
 
-            if target_scope in ["service", "host"]:
-                for record in inventory_records:
-                    if target_scope == "service" and record.get("service_name") == service_name:
-                        host_only_targets.add(record["hostname"])
-                    elif target_scope == "host" and record.get("hostname") == entity.get("hostname"):
-                        host_only_targets.add(record["hostname"])
-                continue
+            conditions: List[str] = []
+            params = {"service_name": service_name}
 
-            for record in inventory_records:
-                hostname = record.get("hostname")
-                pid = record.get("pid")
-                if hostname is None or pid is None:
+            if target_scope == "namespace":
+                conditions.append("hc.namespace IS NOT DISTINCT FROM %(e_namespace)s")
+                params["e_namespace"] = entity.get("namespace")
+            elif target_scope == "workload":
+                conditions.append("hc.workload_name IS NOT DISTINCT FROM %(e_workload)s")
+                params["e_workload"] = entity.get("workload_name")
+                if entity.get("namespace") is not None:
+                    conditions.append("hc.namespace = %(e_namespace)s")
+                    params["e_namespace"] = entity.get("namespace")
+            elif target_scope == "pod":
+                conditions.append("hc.pod_name IS NOT DISTINCT FROM %(e_pod)s")
+                params["e_pod"] = entity.get("pod_name")
+                if entity.get("namespace") is not None:
+                    conditions.append("hc.namespace = %(e_namespace)s")
+                    params["e_namespace"] = entity.get("namespace")
+            elif target_scope == "container":
+                conditions.append("hc.container_name IS NOT DISTINCT FROM %(e_container)s")
+                params["e_container"] = entity.get("container_name")
+                if entity.get("pod_name") is not None:
+                    conditions.append("hc.pod_name = %(e_pod)s")
+                    params["e_pod"] = entity.get("pod_name")
+                if entity.get("namespace") is not None:
+                    conditions.append("hc.namespace = %(e_namespace)s")
+                    params["e_namespace"] = entity.get("namespace")
+            elif target_scope == "process":
+                # (pid match) OR (process_name match + optional container/pod/namespace),
+                # mirroring the original disjunction.
+                or_parts: List[str] = []
+                if entity.get("pid") is not None:
+                    or_parts.append("hp.pid = %(e_pid)s")
+                    params["e_pid"] = entity.get("pid")
+                if entity.get("process_name") is not None:
+                    name_conditions = ["hp.process_name = %(e_process)s"]
+                    params["e_process"] = entity.get("process_name")
+                    if entity.get("container_name") is not None:
+                        name_conditions.append("hc.container_name = %(e_container)s")
+                        params["e_container"] = entity.get("container_name")
+                    if entity.get("pod_name") is not None:
+                        name_conditions.append("hc.pod_name = %(e_pod)s")
+                        params["e_pod"] = entity.get("pod_name")
+                    if entity.get("namespace") is not None:
+                        name_conditions.append("hc.namespace = %(e_namespace)s")
+                        params["e_namespace"] = entity.get("namespace")
+                    or_parts.append("(" + " AND ".join(name_conditions) + ")")
+                if not or_parts:
                     continue
+                conditions.append("(" + " OR ".join(or_parts) + ")")
+            else:
+                continue
 
-                matches = False
-                if target_scope == "namespace":
-                    matches = record.get("namespace") == entity.get("namespace")
-                elif target_scope == "workload":
-                    matches = (
-                        record.get("workload_name") == entity.get("workload_name")
-                        and (entity.get("namespace") is None or record.get("namespace") == entity.get("namespace"))
-                    )
-                elif target_scope == "pod":
-                    matches = (
-                        record.get("pod_name") == entity.get("pod_name")
-                        and (entity.get("namespace") is None or record.get("namespace") == entity.get("namespace"))
-                    )
-                elif target_scope == "container":
-                    matches = (
-                        record.get("container_name") == entity.get("container_name")
-                        and (entity.get("pod_name") is None or record.get("pod_name") == entity.get("pod_name"))
-                        and (entity.get("namespace") is None or record.get("namespace") == entity.get("namespace"))
-                    )
-                elif target_scope == "process":
-                    matches = (
-                        (entity.get("pid") is not None and pid == entity.get("pid"))
-                        or (
-                            entity.get("process_name") is not None
-                            and record.get("process_name") == entity.get("process_name")
-                            and (entity.get("container_name") is None or record.get("container_name") == entity.get("container_name"))
-                            and (entity.get("pod_name") is None or record.get("pod_name") == entity.get("pod_name"))
-                            and (entity.get("namespace") is None or record.get("namespace") == entity.get("namespace"))
-                        )
-                    )
+            where_extra = (" AND " + " AND ".join(conditions)) if conditions else ""
+            query = f"SELECT h.hostname, hp.pid {base_from}{where_extra}"
+            rows = self.db.execute(query, params, one_value=False, return_dict=True, fetch_all=True)
+            for row in rows or []:
+                if row.get("hostname") is not None and row.get("pid") is not None:
+                    host_pid_mapping[row["hostname"]].add(row["pid"])
 
-                if matches:
-                    host_pid_mapping[hostname].add(pid)
-
-        resolved_targets: Dict[str, Optional[List[int]]] = {hostname: None for hostname in sorted(host_only_targets)}
-        for hostname, pid_set in host_pid_mapping.items():
-            resolved_targets[hostname] = sorted(pid_set)
-        return resolved_targets
+        return {hostname: sorted(pid_set) for hostname, pid_set in host_pid_mapping.items()}
 
     def get_profiling_host_status_optimized(
         self,

--- a/src/gprofiler-dev/gprofiler_dev/postgres/postgresdb.py
+++ b/src/gprofiler-dev/gprofiler_dev/postgres/postgresdb.py
@@ -60,6 +60,43 @@ class PostgresDB:
         with self._conn_lock:
             yield self._thread_unsafe_conn
 
+    @contextmanager
+    def transaction(self, return_dict: bool = False):
+        """Run multiple statements on a single connection within one transaction.
+
+        Yields a cursor; commits on success, rolls back on any exception. Use this
+        when a logical write spans several statements that must be atomic (e.g. a
+        parent upsert followed by dependent child writes).
+
+        Unlike ``execute`` this does not retry mid-transaction (a context manager
+        can only yield once), so it probes the connection up front and reconnects
+        once if it is dead before handing out the cursor.
+        """
+        with self._conn_lock:
+            with self.get_locked_conn() as current_conn:
+                try:
+                    if current_conn.closed:
+                        self._reconnect()
+                        current_conn = self._thread_unsafe_conn
+                except Exception:
+                    self._reconnect()
+                    current_conn = self._thread_unsafe_conn
+
+                cursor = current_conn.cursor(
+                    cursor_factory=psycopg2.extras.RealDictCursor if return_dict else None
+                )
+                try:
+                    yield cursor
+                    current_conn.commit()
+                except Exception:
+                    try:
+                        current_conn.rollback()
+                    except Exception:
+                        pass
+                    raise
+                finally:
+                    cursor.close()
+
     @staticmethod
     def _execute(
         cursor,

--- a/src/gprofiler/backend/models/metrics_models.py
+++ b/src/gprofiler/backend/models/metrics_models.py
@@ -18,7 +18,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from backend.models import CamelModel
-from pydantic import BaseModel, root_validator, validator
+from pydantic import BaseModel, Field, root_validator, validator
 
 
 class SampleCount(BaseModel):
@@ -89,6 +89,36 @@ class HTMLMetadata(CamelModel):
     content: str
 
 
+class WorkloadTargetEntity(CamelModel):
+    id: Optional[str] = None
+    service_name: Optional[str] = None
+    namespace: Optional[str] = None
+    hostname: Optional[str] = None
+    ip_address: Optional[str] = None
+    pod_name: Optional[str] = None
+    container_name: Optional[str] = None
+    workload_name: Optional[str] = None
+    workload_kind: Optional[str] = None
+    pid: Optional[int] = None
+    process_name: Optional[str] = None
+
+
+class HeartbeatProcessInfo(CamelModel):
+    pid: int
+    process_name: str
+
+
+class HeartbeatContainerInfo(CamelModel):
+    container_id: Optional[str] = None
+    container_name: str
+    runtime: Optional[str] = None
+    namespace: Optional[str] = None
+    pod_name: Optional[str] = None
+    workload_name: Optional[str] = None
+    workload_kind: Optional[str] = None
+    processes: List[HeartbeatProcessInfo] = Field(default_factory=list)
+
+
 class ProfilingRequest(BaseModel):
     """Model for profiling request parameters"""
 
@@ -98,7 +128,9 @@ class ProfilingRequest(BaseModel):
     duration: Optional[int] = 60
     frequency: Optional[int] = 11
     profiling_mode: Optional[str] = "cpu"  # "cpu", "allocation", "none"
-    target_hosts: Dict[str, Optional[List[int]]]
+    target_hosts: Optional[Dict[str, Optional[List[int]]]] = None
+    target_scope: Optional[str] = "host"
+    target_entities: Optional[List[WorkloadTargetEntity]] = None
     stop_level: Optional[str] = "process"  # "process" or "host"
     additional_args: Optional[Dict[str, Any]] = None
     dry_run: Optional[bool] = False
@@ -115,10 +147,16 @@ class ProfilingRequest(BaseModel):
             raise ValueError('profiling_mode must be "cpu", "allocation", or "none"')
         return v
 
+    @validator("target_scope")
+    def validate_target_scope(cls, v):
+        if v not in ["host", "service", "namespace", "workload", "pod", "container", "process"]:
+            raise ValueError('target_scope must be one of "host", "service", "namespace", "workload", "pod", "container", or "process"')
+        return v
+
     @validator("target_hosts")
     def validate_target_hosts(cls, v):
-        """Validate that target_hosts is not empty."""
-        if len(v) == 0:
+        """Validate that target_hosts is not empty when provided."""
+        if v is not None and len(v) == 0:
             raise ValueError("target_hosts cannot be empty")
         return v
 
@@ -142,23 +180,29 @@ class ProfilingRequest(BaseModel):
 
     @root_validator
     def validate_profile_request(cls, values):
-        """Validate that PIDs are provided when request_type is stop and stop_level is process"""
+        """Validate target requirements for host- and workload-level requests."""
         request_type = values.get("request_type")
         stop_level = values.get("stop_level")
         target_hosts = values.get("target_hosts")
+        target_entities = values.get("target_entities") or []
+
+        if not target_hosts and not target_entities:
+            raise ValueError("At least one target_hosts entry or target_entities selector must be provided")
 
         if request_type == "stop" and stop_level == "process":
             # Check if PIDs are provided in target_hosts mapping
             has_pids = target_hosts and any(pids for pids in target_hosts.values() if pids)
-            if not has_pids:
+            has_entity_targets = len(target_entities) > 0
+            if not has_pids and not has_entity_targets:
                 raise ValueError(
-                    'At least one PID must be provided when request_type is "stop" and stop_level is "process"'
+                    'At least one PID or workload selector must be provided when request_type is "stop" and stop_level is "process"'
                 )
 
         # Validate if a process id is provided when request_type is stop and stop_level is host, if so raises
         if request_type == "stop" and stop_level == "host":
             has_pids = target_hosts and any(pids for pids in target_hosts.values() if pids is not None)
-            if has_pids:
+            has_process_entities = any(entity.pid is not None for entity in target_entities)
+            if has_pids or has_process_entities:
                 raise ValueError('No PIDs should be provided when request_type is "stop" and stop_level is "host"')
 
         return values
@@ -224,6 +268,11 @@ class HeartbeatRequest(BaseModel):
     ip_address: str
     hostname: str
     service_name: str
+    agent_version: Optional[str] = None
+    run_mode: Optional[str] = None
+    namespace: Optional[str] = None
+    pod_name: Optional[str] = None
+    containers: Optional[List[HeartbeatContainerInfo]] = None
     last_command_id: Optional[str] = None
     received_command_ids: Optional[List[str]] = None
     executed_command_ids: Optional[List[str]] = None
@@ -286,3 +335,65 @@ class ProfilingHostStatusResponse(BaseModel):
     hosts: List[ProfilingHostStatus]
     active_count: int  # Hosts with heartbeat in last 2 minutes
     total_count: int   # total number of hosts for the selected service
+
+
+class ProfilingInventoryStatusRequest(BaseModel):
+    """Model for workload inventory status request parameters."""
+
+    scope: str = "host"
+    service_name: Optional[List[str]] = None
+    exact_match: bool = False
+    hostname: Optional[List[str]] = None
+    ip_address: Optional[List[str]] = None
+    namespace: Optional[List[str]] = None
+    pod_name: Optional[List[str]] = None
+    container_name: Optional[List[str]] = None
+    workload_name: Optional[List[str]] = None
+    process_name: Optional[List[str]] = None
+    profiling_status: Optional[List[str]] = None
+    command_type: Optional[List[str]] = None
+    pids: Optional[List[int]] = None
+
+    @validator("scope")
+    def validate_scope(cls, v):
+        if v not in ["service", "namespace", "host", "pod", "container", "process"]:
+            raise ValueError('scope must be one of "service", "namespace", "host", "pod", "container", or "process"')
+        return v
+
+
+class ProfilingInventoryStatus(CamelModel):
+    id: str
+    scope: str
+    service_name: str
+    namespace: Optional[str] = None
+    hostname: Optional[str] = None
+    ip_address: Optional[str] = None
+    pod_name: Optional[str] = None
+    container_name: Optional[str] = None
+    workload_name: Optional[str] = None
+    workload_kind: Optional[str] = None
+    process_name: Optional[str] = None
+    pid: Optional[int] = None
+    pids: Optional[List[int]] = None
+    active_hosts: Optional[int] = None
+    host_count: Optional[int] = None
+    namespace_count: Optional[int] = None
+    pod_count: Optional[int] = None
+    container_count: Optional[int] = None
+    process_count: Optional[int] = None
+    command_type: Optional[str] = None
+    profiling_status: Optional[str] = None
+    profiling_mode: Optional[str] = None
+    frequency: Optional[int] = None
+    profiler_summary: Optional[str] = None
+    heartbeat_timestamp: Optional[datetime] = None
+    agent_version: Optional[str] = None
+    run_mode: Optional[str] = None
+
+
+class ProfilingInventoryStatusResponse(CamelModel):
+    scope: str
+    rows: List[ProfilingInventoryStatus]
+    tab_counts: Dict[str, int]
+    active_hosts: int
+    total_count: int

--- a/src/gprofiler/backend/routers/metrics_routes.py
+++ b/src/gprofiler/backend/routers/metrics_routes.py
@@ -38,6 +38,8 @@ from backend.models.metrics_models import (
     MetricNodesAndCores,
     MetricNodesCoresSummary,
     MetricSummary,
+    ProfilingInventoryStatusRequest,
+    ProfilingInventoryStatusResponse,
     ProfilingHostStatus,
     ProfilingHostStatusRequest,
     ProfilingHostStatusResponse,
@@ -120,6 +122,38 @@ def profiling_host_status_params(
         exact_match=exact_match,
         hostname=hostname,
         ip_address=ip_address,
+        profiling_status=profiling_status,
+        command_type=command_type,
+        pids=pids,
+    )
+
+
+def profiling_inventory_status_params(
+    scope: str = Query("host", description="Inventory scope: service, namespace, host, pod, container, process"),
+    service_name: Optional[List[str]] = Query(None, description="Filter by service name(s)"),
+    exact_match: bool = Query(False, description="Use exact match for service name (default: false for partial matching)"),
+    hostname: Optional[List[str]] = Query(None, description="Filter by hostname(s)"),
+    ip_address: Optional[List[str]] = Query(None, description="Filter by IP address(es)"),
+    namespace: Optional[List[str]] = Query(None, description="Filter by namespace(s)"),
+    pod_name: Optional[List[str]] = Query(None, description="Filter by pod name(s)"),
+    container_name: Optional[List[str]] = Query(None, description="Filter by container name(s)"),
+    workload_name: Optional[List[str]] = Query(None, description="Filter by workload name(s)"),
+    process_name: Optional[List[str]] = Query(None, description="Filter by process name(s)"),
+    profiling_status: Optional[List[str]] = Query(None, description="Filter by profiling status(es)"),
+    command_type: Optional[List[str]] = Query(None, description="Filter by command type(s)"),
+    pids: Optional[List[int]] = Query(None, description="Filter by PIDs"),
+) -> ProfilingInventoryStatusRequest:
+    return ProfilingInventoryStatusRequest(
+        scope=scope,
+        service_name=service_name,
+        exact_match=exact_match,
+        hostname=hostname,
+        ip_address=ip_address,
+        namespace=namespace,
+        pod_name=pod_name,
+        container_name=container_name,
+        workload_name=workload_name,
+        process_name=process_name,
         profiling_status=profiling_status,
         command_type=command_type,
         pids=pids,
@@ -327,6 +361,21 @@ def create_profiling_request(profiling_request: ProfilingRequest) -> ProfilingRe
         )
         db_manager = DBManager()
 
+        target_entities = [entity.dict() for entity in (profiling_request.target_entities or [])]
+        target_scope = profiling_request.target_scope or "host"
+        resolved_target_hosts = profiling_request.target_hosts or {}
+        if target_entities or target_scope != "host":
+            resolved_target_hosts = db_manager.resolve_workload_targets(
+                service_name=profiling_request.service_name,
+                target_scope=target_scope,
+                target_entities=target_entities,
+            )
+            if not resolved_target_hosts:
+                raise HTTPException(
+                    status_code=422,
+                    detail=f"No active targets were resolved for scope '{target_scope}' in service '{profiling_request.service_name}'",
+                )
+
         # Handle dry run requests.
         # No DB changes, just validate and return success.
         if profiling_request.dry_run:
@@ -343,10 +392,10 @@ def create_profiling_request(profiling_request: ProfilingRequest) -> ProfilingRe
 
         try:
             # Convert target_hosts to legacy format for database compatibility
-            target_hostnames = list(profiling_request.target_hosts.keys()) if profiling_request.target_hosts else None
+            target_hostnames = list(resolved_target_hosts.keys()) if resolved_target_hosts else None
             host_pid_mapping = (
-                {hostname: pids for hostname, pids in profiling_request.target_hosts.items() if pids}
-                if profiling_request.target_hosts
+                {hostname: pids for hostname, pids in resolved_target_hosts.items() if pids}
+                if resolved_target_hosts
                 else None
             )
 
@@ -362,6 +411,8 @@ def create_profiling_request(profiling_request: ProfilingRequest) -> ProfilingRe
                 target_hostnames=target_hostnames,
                 pids=None,  # Deprecated field, always None
                 host_pid_mapping=host_pid_mapping,
+                target_scope=target_scope,
+                target_entities=target_entities,
                 additional_args=profiling_request.additional_args,
             )
 
@@ -374,8 +425,8 @@ def create_profiling_request(profiling_request: ProfilingRequest) -> ProfilingRe
                 target_hosts = []
 
                 # Determine target hosts from target_hosts mapping
-                if profiling_request.target_hosts:
-                    target_hosts = list(profiling_request.target_hosts.keys())
+                if resolved_target_hosts:
+                    target_hosts = list(resolved_target_hosts.keys())
 
                 if target_hosts:
                     # Create commands for specific hosts
@@ -406,8 +457,8 @@ def create_profiling_request(profiling_request: ProfilingRequest) -> ProfilingRe
                 target_hosts = []
 
                 # Determine target hosts for stop commands
-                if profiling_request.target_hosts:
-                    target_hosts = list(profiling_request.target_hosts.keys())
+                if resolved_target_hosts:
+                    target_hosts = list(resolved_target_hosts.keys())
 
                 if target_hosts:
                     for hostname in target_hosts:
@@ -425,8 +476,8 @@ def create_profiling_request(profiling_request: ProfilingRequest) -> ProfilingRe
                         else:  # process level stop
                             # Get PIDs for this specific host from target_hosts mapping
                             host_pids = None
-                            if profiling_request.target_hosts and hostname in profiling_request.target_hosts:
-                                host_pids = profiling_request.target_hosts[hostname]
+                            if resolved_target_hosts and hostname in resolved_target_hosts:
+                                host_pids = resolved_target_hosts[hostname]
 
                             # Stop specific processes for this host
                             db_manager.handle_process_level_stop(
@@ -709,6 +760,11 @@ def receive_heartbeat(heartbeat: HeartbeatRequest):
                 hostname=heartbeat.hostname,
                 ip_address=heartbeat.ip_address,
                 service_name=heartbeat.service_name,
+                agent_version=heartbeat.agent_version,
+                run_mode=heartbeat.run_mode,
+                namespace=heartbeat.namespace,
+                pod_name=heartbeat.pod_name,
+                containers=[container.dict() for container in (heartbeat.containers or [])],
                 last_command_id=heartbeat.last_command_id,
                 received_command_ids=heartbeat.received_command_ids,
                 executed_command_ids=heartbeat.executed_command_ids,
@@ -973,6 +1029,28 @@ def get_profiling_host_status(
         hosts=results,
         active_count=len(results),
         total_count=total_count
+    )
+
+
+@router.get("/profiling/workload_status", response_model=ProfilingInventoryStatusResponse)
+def get_profiling_workload_status(
+    profiling_params: ProfilingInventoryStatusRequest = Depends(profiling_inventory_status_params),
+):
+    db_manager = DBManager()
+    return db_manager.get_workload_inventory_status(
+        scope=profiling_params.scope,
+        service_names=profiling_params.service_name,
+        hostnames=profiling_params.hostname,
+        ip_addresses=profiling_params.ip_address,
+        namespaces=profiling_params.namespace,
+        pod_names=profiling_params.pod_name,
+        container_names=profiling_params.container_name,
+        workload_names=profiling_params.workload_name,
+        process_names=profiling_params.process_name,
+        profiling_statuses=profiling_params.profiling_status,
+        command_types=profiling_params.command_type,
+        pids=profiling_params.pids,
+        exact_match=profiling_params.exact_match,
     )
 
 

--- a/src/gprofiler/backend/routers/metrics_routes.py
+++ b/src/gprofiler/backend/routers/metrics_routes.py
@@ -773,6 +773,24 @@ def receive_heartbeat(heartbeat: HeartbeatRequest):
                 supported_perf_events=heartbeat.perf_supported_events,  # Use agent field name
             )
 
+            # 1b. Auto-subscribe newly-registered hosts to an active service-wide
+            # profiling session. Hosts that join a service after a service-scoped
+            # request was issued (e.g. cluster autoscaling) are enrolled here so
+            # users do not have to re-select the service.
+            try:
+                if db_manager.auto_subscribe_host_to_service(
+                    hostname=heartbeat.hostname,
+                    service_name=heartbeat.service_name,
+                ):
+                    logger.info(
+                        f"Auto-subscribed host {heartbeat.hostname} to active service-wide "
+                        f"profiling for service {heartbeat.service_name}"
+                    )
+            except Exception as e:
+                logger.warning(
+                    f"Auto-subscribe check failed for {heartbeat.hostname}/{heartbeat.service_name}: {e}"
+                )
+
             # 2. Check for current profiling command for this host/service
             current_command = db_manager.get_current_profiling_command(
                 hostname=heartbeat.hostname,

--- a/src/gprofiler/backend/utils/dynamic_profiling_utils.py
+++ b/src/gprofiler/backend/utils/dynamic_profiling_utils.py
@@ -155,12 +155,22 @@ def validate_pmu_events(
             
             # Only validate if perf is enabled and events are specified
             if perf_mode != "disabled" and perf_events:
-                target_hostnames_for_service = list(profiling_request.target_hosts.keys())
-                
+                # target_hosts is only populated for host-scope requests. For
+                # workload scopes (service/namespace/pod/container/process) the
+                # UI sends no target_hosts because the concrete hosts are
+                # resolved later; fall back to None so events are validated
+                # against all of the service's active hosts instead of crashing
+                # on None.keys().
+                target_hostnames_for_service = (
+                    list(profiling_request.target_hosts.keys())
+                    if profiling_request.target_hosts
+                    else None
+                )
+
                 validation_result = db_manager.validate_perf_events_support(
                     service_name=profiling_request.service_name,
                     requested_events=perf_events,
-                    target_hostnames=target_hostnames_for_service if target_hostnames_for_service else None
+                    target_hostnames=target_hostnames_for_service
                 )
                 
                 if not validation_result["valid"]:

--- a/src/gprofiler/frontend/package.json
+++ b/src/gprofiler/frontend/package.json
@@ -51,7 +51,8 @@
     "format": "prettier --write \"src/**/*.{js,jsx,scss}\"",
     "format-check": "prettier --check \"src/**/*.{js,jsx,scss}\"",
     "eslint": "eslint \"./src/**/*.{js,jsx}\" --max-warnings=0",
-    "eslint-fix": "eslint --fix \"./src/**/*.{js,jsx}\""
+    "eslint-fix": "eslint --fix \"./src/**/*.{js,jsx}\"",
+    "test": "node --test src"
   },
   "browserslist": [
     ">0.2%",

--- a/src/gprofiler/frontend/src/api/urls.js
+++ b/src/gprofiler/frontend/src/api/urls.js
@@ -44,6 +44,7 @@ export const DATA_URLS = {
     GET_API_KEY: `${API_PREFIX}/api_key`,
     // Profiling endpoints
     GET_PROFILING_HOST_STATUS: `${API_PREFIX}/metrics/profiling/host_status`,
+    GET_PROFILING_WORKLOAD_STATUS: `${API_PREFIX}/metrics/profiling/workload_status`,
     POST_PROFILING_REQUEST: `${API_PREFIX}/metrics/profile_request`,
     POST_PROFILING_REQUEST_BULK: `${API_PREFIX}/metrics/profile_request/bulk`,
     POST_HEARTBEAT: `${API_PREFIX}/metrics/heartbeat`,

--- a/src/gprofiler/frontend/src/components/console/ProfilingStatusPage.jsx
+++ b/src/gprofiler/frontend/src/components/console/ProfilingStatusPage.jsx
@@ -137,9 +137,9 @@ const getScopeColumns = (scope) => {
 
     if (scope === 'host') {
         return [
+            { field: 'host', headerName: 'host name', flex: 1.1, sortable: true },
             { field: 'service', headerName: 'service name', flex: 1, sortable: true },
             { field: 'namespace', headerName: 'namespace', flex: 0.9, sortable: true },
-            { field: 'host', headerName: 'host name', flex: 1.1, sortable: true },
             { field: 'pids', headerName: 'pids (if profiled)', flex: 1, sortable: false },
             { field: 'ip', headerName: 'IP', flex: 0.9, sortable: true },
             { field: 'commandType', headerName: 'command type', flex: 0.8, sortable: true },

--- a/src/gprofiler/frontend/src/components/console/ProfilingStatusPage.jsx
+++ b/src/gprofiler/frontend/src/components/console/ProfilingStatusPage.jsx
@@ -24,6 +24,7 @@ import { ICONS_NAMES } from '../common/icon/iconsData';
 import MuiTable from '../common/dataDisplay/table/MuiTable';
 import ProfilingHeader from './header/ProfilingHeader';
 import ProfilingTopPanel from './header/ProfilingTopPanel';
+import { buildProfilingRequests } from './profilingRequestBuilder.mjs';
 
 const DEFAULT_PROFILING_FREQUENCY = 11;
 const DEFAULT_MAX_PROCESSES = 10;
@@ -259,20 +260,6 @@ const rowDisplayName = (row, scope) => {
     return `${row.processName} (${row.pid})`;
 };
 
-const buildTargetEntity = (row) => ({
-    id: row.id,
-    service_name: row.service,
-    namespace: row.namespace || undefined,
-    hostname: row.host || undefined,
-    ip_address: row.ip || undefined,
-    pod_name: row.podName || undefined,
-    container_name: row.containerName || undefined,
-    workload_name: row.workloadName || undefined,
-    workload_kind: row.workloadKind || undefined,
-    pid: row.pid || undefined,
-    process_name: row.processName || undefined,
-});
-
 const ProfilingStatusPage = () => {
     const history = useHistory();
     const location = useLocation();
@@ -442,45 +429,15 @@ const ProfilingStatusPage = () => {
         updateURL(nextScope, appliedFilters);
     };
 
-    const buildRequests = useCallback((action, selectedRows) => {
-        const grouped = selectedRows.reduce((groups, row) => {
-            if (!groups[row.service]) {
-                groups[row.service] = [];
-            }
-            groups[row.service].push(row);
-            return groups;
-        }, {});
-
-        const requests = Object.entries(grouped).map(([serviceName, serviceRows]) => {
-            const targetScope = activeScope;
-            const targetHosts = targetScope === 'host'
-                ? serviceRows.reduce((hostMap, row) => {
-                    hostMap[row.host] = null;
-                    return hostMap;
-                }, {})
-                : undefined;
-
-            return {
-                service_name: serviceName,
-                request_type: action,
-                continuous: profilingMode === 'continuous',
-                duration: profilingMode === 'continuous' ? 60 : duration,
-                frequency: profilingFrequency,
-                profiling_mode: 'cpu',
-                target_scope: targetScope,
-                target_hosts: targetHosts,
-                target_entities: serviceRows.map((row) => buildTargetEntity(row)),
-                stop_level: action === 'stop' ? (['service', 'host'].includes(targetScope) ? 'host' : 'process') : undefined,
-                additional_args: {
-                    enable_perfspect: enablePerfSpect,
-                    profiler_configs: profilerConfigs,
-                    max_processes: maxProcesses,
-                },
-            };
-        });
-
-        return { grouped, requests };
-    }, [activeScope, duration, enablePerfSpect, maxProcesses, profilerConfigs, profilingFrequency, profilingMode]);
+    const buildRequests = useCallback((action, selectedRows) => buildProfilingRequests(action, selectedRows, {
+        scope: activeScope,
+        profilingMode,
+        duration,
+        profilingFrequency,
+        enablePerfSpect,
+        profilerConfigs,
+        maxProcesses,
+    }), [activeScope, duration, enablePerfSpect, maxProcesses, profilerConfigs, profilingFrequency, profilingMode]);
 
     const executeDryRun = useCallback((action, selectedRows) => {
         const { requests } = buildRequests(action, selectedRows);

--- a/src/gprofiler/frontend/src/components/console/ProfilingStatusPage.jsx
+++ b/src/gprofiler/frontend/src/components/console/ProfilingStatusPage.jsx
@@ -1,4 +1,5 @@
 import {
+    Alert,
     Box,
     Button,
     Chip,
@@ -7,6 +8,7 @@ import {
     DialogContent,
     DialogTitle,
     Divider,
+    Snackbar,
     Tab,
     Tabs,
     Typography,
@@ -17,6 +19,8 @@ import { useHistory, useLocation } from 'react-router-dom';
 
 import { DATA_URLS } from '../../api/urls';
 import { PAGES } from '../../utils/consts';
+import Icon from '../common/icon/Icon';
+import { ICONS_NAMES } from '../common/icon/iconsData';
 import MuiTable from '../common/dataDisplay/table/MuiTable';
 import ProfilingHeader from './header/ProfilingHeader';
 import ProfilingTopPanel from './header/ProfilingTopPanel';
@@ -24,6 +28,7 @@ import ProfilingTopPanel from './header/ProfilingTopPanel';
 const DEFAULT_PROFILING_FREQUENCY = 11;
 const DEFAULT_MAX_PROCESSES = 10;
 const DEFAULT_DURATION = 60;
+const CONFIG_STORAGE_KEY = 'gprofiler.adhocProfilingConfig';
 
 const SCOPES = [
     { id: 'service', label: 'Services' },
@@ -307,8 +312,42 @@ const ProfilingStatusPage = () => {
         isValid: false,
         errors: [],
     });
+    const [snackbar, setSnackbar] = useState({ open: false, message: '' });
 
     const columns = useMemo(() => getScopeColumns(activeScope), [activeScope]);
+
+    useEffect(() => {
+        try {
+            const saved = JSON.parse(localStorage.getItem(CONFIG_STORAGE_KEY));
+            if (saved) {
+                if (typeof saved.enablePerfSpect === 'boolean') setEnablePerfSpect(saved.enablePerfSpect);
+                if (saved.profilingFrequency) setProfilingFrequency(saved.profilingFrequency);
+                if (saved.maxProcesses != null) setMaxProcesses(saved.maxProcesses);
+                if (saved.profilingMode) setProfilingMode(saved.profilingMode);
+                if (saved.duration) setDuration(saved.duration);
+                if (saved.profilerConfigs) setProfilerConfigs(saved.profilerConfigs);
+            }
+        } catch (error) {
+            // ignore malformed persisted config
+        }
+    }, []);
+
+    const handleSaveConfiguration = useCallback(() => {
+        const config = {
+            enablePerfSpect,
+            profilingFrequency,
+            maxProcesses,
+            profilingMode,
+            duration,
+            profilerConfigs,
+        };
+        try {
+            localStorage.setItem(CONFIG_STORAGE_KEY, JSON.stringify(config));
+            setSnackbar({ open: true, message: 'Configuration saved' });
+        } catch (error) {
+            setSnackbar({ open: true, message: 'Failed to save configuration' });
+        }
+    }, [duration, enablePerfSpect, maxProcesses, profilerConfigs, profilingFrequency, profilingMode]);
 
     const fetchProfilingStatus = useCallback((filterParams, scope = activeScope) => {
         setLoading(true);
@@ -519,6 +558,37 @@ const ProfilingStatusPage = () => {
 
     return (
         <Box sx={{ backgroundColor: 'white.main', height: '100%' }}>
+            <Box
+                sx={{
+                    px: 4,
+                    pt: 3,
+                    pb: 1,
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'flex-start',
+                    gap: 2,
+                }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+                    <Icon name={ICONS_NAMES.Crosshairs} size={28} color="#583FFD" />
+                    <Box>
+                        <Typography variant="h5" sx={{ fontWeight: 700, lineHeight: 1.2 }}>
+                            Adhoc Profile Configuration
+                        </Typography>
+                        <Typography variant="body2" color="text.secondary">
+                            Select workloads and configure profiling parameters
+                        </Typography>
+                    </Box>
+                </Box>
+                <Box sx={{ textAlign: 'right', whiteSpace: 'nowrap' }}>
+                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                        Active Hosts
+                    </Typography>
+                    <Typography variant="subtitle1" sx={{ fontWeight: 700, color: '#16a34a' }}>
+                        {(activeCount || 0).toLocaleString()} of {(totalCount || 0).toLocaleString()}
+                    </Typography>
+                </Box>
+            </Box>
+
             <ProfilingHeader
                 filters={filters}
                 updateFilter={updateFilter}
@@ -540,17 +610,30 @@ const ProfilingStatusPage = () => {
             </Box>
 
             <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                <Box sx={{ px: 4, pt: 3, pb: 1, '& .MuiDataGrid-root': { border: 'none' } }}>
+                    <MuiTable
+                        columns={columns}
+                        data={rows}
+                        isLoading={loading}
+                        pageSize={50}
+                        rowHeight={50}
+                        autoPageSize
+                        checkboxSelection
+                        onSelectionModelChange={setSelectionModel}
+                        selectionModel={selectionModel}
+                    />
+                    <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
+                        Showing {rows.length} {scopeEntityLabel(activeScope)}
+                        {selectionModel.length ? ` \u00b7 ${selectionModel.length} selected` : ''}
+                    </Typography>
+                </Box>
+
                 <ProfilingTopPanel
                     selectionModel={selectionModel}
                     handleBulkAction={handleBulkAction}
                     fetchProfilingStatus={(scopeFilters) => fetchProfilingStatus(scopeFilters, activeScope)}
                     filters={appliedFilters}
                     loading={loading}
-                    activeCount={activeCount}
-                    totalCount={totalCount}
-                    activeLabel="active hosts"
-                    totalLabel={scopeEntityLabel(activeScope)}
-                    clearAllFilters={clearAllFilters}
                     enablePerfSpect={enablePerfSpect}
                     onPerfSpectChange={setEnablePerfSpect}
                     profilingFrequency={profilingFrequency}
@@ -563,21 +646,8 @@ const ProfilingStatusPage = () => {
                     onDurationChange={setDuration}
                     profilerConfigs={profilerConfigs}
                     onProfilerConfigsChange={setProfilerConfigs}
+                    onSaveConfiguration={handleSaveConfiguration}
                 />
-
-                <Box sx={{ p: 4, '& .MuiDataGrid-root': { border: 'none' } }}>
-                    <MuiTable
-                        columns={columns}
-                        data={rows}
-                        isLoading={loading}
-                        pageSize={50}
-                        rowHeight={50}
-                        autoPageSize
-                        checkboxSelection
-                        onSelectionModelChange={setSelectionModel}
-                        selectionModel={selectionModel}
-                    />
-                </Box>
             </Box>
 
             <Dialog open={confirmationDialog.open} onClose={handleDialogClose} maxWidth="md" fullWidth>
@@ -702,6 +772,22 @@ const ProfilingStatusPage = () => {
                     </Button>
                 </DialogActions>
             </Dialog>
+
+            <Snackbar
+                open={snackbar.open}
+                autoHideDuration={3000}
+                onClose={() => setSnackbar({ open: false, message: '' })}
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+            >
+                <Alert
+                    onClose={() => setSnackbar({ open: false, message: '' })}
+                    severity="success"
+                    variant="filled"
+                    sx={{ width: '100%' }}
+                >
+                    {snackbar.message}
+                </Alert>
+            </Snackbar>
         </Box>
     );
 };

--- a/src/gprofiler/frontend/src/components/console/ProfilingStatusPage.jsx
+++ b/src/gprofiler/frontend/src/components/console/ProfilingStatusPage.jsx
@@ -1,31 +1,78 @@
-import { 
-    Box, 
-    Typography, 
-    Dialog, 
-    DialogTitle, 
-    DialogContent, 
-    DialogActions, 
-    Button, 
-    Divider, 
-    Chip 
+import {
+    Box,
+    Button,
+    Chip,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    Divider,
+    Tab,
+    Tabs,
+    Typography,
 } from '@mui/material';
 import queryString from 'query-string';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { DATA_URLS } from '../../api/urls';
 import { PAGES } from '../../utils/consts';
 import MuiTable from '../common/dataDisplay/table/MuiTable';
-import PageHeader from '../common/layout/PageHeader';
 import ProfilingHeader from './header/ProfilingHeader';
 import ProfilingTopPanel from './header/ProfilingTopPanel';
 
-// Constants
 const DEFAULT_PROFILING_FREQUENCY = 11;
 const DEFAULT_MAX_PROCESSES = 10;
 const DEFAULT_DURATION = 60;
 
-// Helper function to build profile URL
+const SCOPES = [
+    { id: 'service', label: 'Services' },
+    { id: 'namespace', label: 'Namespaces' },
+    { id: 'host', label: 'Hosts' },
+    { id: 'pod', label: 'Pods' },
+    { id: 'container', label: 'Containers' },
+    { id: 'process', label: 'Processes' },
+];
+
+const EMPTY_FILTERS = {
+    service: '',
+    hostname: '',
+    pids: '',
+    ip: '',
+    namespace: '',
+    podName: '',
+    containerName: '',
+    processName: '',
+    commandType: '',
+    status: '',
+};
+
+const readField = (row, camelKey, snakeKey = camelKey) => row[camelKey] ?? row[snakeKey];
+
+const formatHeartbeat = (value) => {
+    if (!value) {
+        return 'N/A';
+    }
+
+    try {
+        let utcTimestamp = value;
+        if (!utcTimestamp.endsWith('Z') && !utcTimestamp.includes('+') && !utcTimestamp.includes('-', 10)) {
+            utcTimestamp += 'Z';
+        }
+        return new Date(utcTimestamp).toLocaleString(navigator.language, {
+            day: '2-digit',
+            month: '2-digit',
+            year: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+            hour12: true,
+        });
+    } catch (error) {
+        return 'Invalid date';
+    }
+};
+
 const buildProfileUrl = (host, service, view) => {
     const baseUrl = `${window.location.protocol}//${window.location.host}`;
     const params = {
@@ -33,546 +80,476 @@ const buildProfileUrl = (host, service, view) => {
         gtab: '1',
         pm: '1',
         rtms: '1',
-        service: service,
+        service,
         time: '1h',
-        view: view,
-        wp: '100'
+        view,
+        wp: '100',
     };
-    const queryParams = new URLSearchParams(params).toString();
-    return `${baseUrl}${PAGES.profiles.to}?${queryParams}`;
+    return `${baseUrl}${PAGES.profiles.to}?${new URLSearchParams(params).toString()}`;
 };
 
-const columns = [
-    { field: 'service', headerName: 'service name', flex: 1, sortable: true },
-    { field: 'host', headerName: 'host name', flex: 1, sortable: true },
-    { field: 'pids', headerName: 'pids (if profiled)', flex: 1, sortable: true },
-    { field: 'ip', headerName: 'IP', flex: 1, sortable: true },
-    { field: 'commandType', headerName: 'command type', flex: 1, sortable: true },
-    { field: 'status', headerName: 'profiling status', flex: 1, sortable: true },
-    {
-        field: 'heartbeat_timestamp',
+const getScopeColumns = (scope) => {
+    const sharedTimestampColumn = {
+        field: 'heartbeatTimestamp',
         headerName: 'last heartbeat',
         flex: 1,
         sortable: true,
-        renderCell: (params) => {
-            if (!params.value) return 'N/A';
-            try {
-                // The backend sends UTC timestamp without 'Z' suffix, so we need to explicitly treat it as UTC
-                let utcTimestamp = params.value;
-                if (!utcTimestamp.endsWith('Z') && !utcTimestamp.includes('+') && !utcTimestamp.includes('-', 10)) {
-                    utcTimestamp += 'Z';
-                }
+        renderCell: (params) => formatHeartbeat(params.value),
+    };
+    const sharedStatusColumns = [
+        { field: 'profilingStatus', headerName: 'profiling', flex: 1, sortable: true },
+        { field: 'profilingMode', headerName: 'mode', flex: 1, sortable: true },
+        { field: 'profilerSummary', headerName: 'profilers', flex: 1.3, sortable: false },
+        { field: 'frequency', headerName: 'frequency', flex: 0.8, sortable: true },
+    ];
 
-                const utcDate = new Date(utcTimestamp);
-                // Convert to user's local timezone
-                const localDateTimeString = utcDate.toLocaleString(navigator.language, {
-                    day: '2-digit',
-                    month: '2-digit',
-                    year: 'numeric',
-                    hour: '2-digit',
-                    minute: '2-digit',
-                    second: '2-digit',
-                    hour12: true,
-                });
-                return localDateTimeString;
-            } catch (error) {
-                return 'Invalid date';
-            }
-        },
-    },
-    {
-        field: 'profile',
-        headerName: 'profile',
-        flex: 1,
-        renderCell: (params) => {
-            const { host, service, commandType, status } = params.row;
-            
-            // Only show profile link for rows with commandType="start" and status="completed"
-            if (commandType !== 'start' || status !== 'completed') {
-                return '';
-            }
-            
-            if (!host || !service) return '';
-            
-            const continuousProfileUrl = buildProfileUrl(host, service, 'flamegraph');
-            const adhocProfileUrl = buildProfileUrl(host, service, 'adhoc');
-            
-            return (
-                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
-                <a
-                        href={continuousProfileUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        style={{ color: '#1976d2', textDecoration: 'none', fontSize: '0.875rem' }}
-                        onMouseOver={(e) => e.target.style.textDecoration = 'underline'}
-                        onMouseOut={(e) => e.target.style.textDecoration = 'none'}
-                    >
-                        View Continuous Profile
-                    </a>
-                    <a
-                        href={adhocProfileUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                        style={{ color: '#1976d2', textDecoration: 'none', fontSize: '0.875rem' }}
-                    onMouseOver={(e) => e.target.style.textDecoration = 'underline'}
-                    onMouseOut={(e) => e.target.style.textDecoration = 'none'}
-                >
-                        View Adhoc Profile
-                </a>
-                </Box>
-            );
-        },
-    },
-];
+    if (scope === 'service') {
+        return [
+            { field: 'service', headerName: 'service name', flex: 1.4, sortable: true },
+            { field: 'namespaceCount', headerName: 'namespaces', flex: 0.8, sortable: true },
+            { field: 'hostCount', headerName: 'hosts', flex: 0.7, sortable: true },
+            { field: 'podCount', headerName: 'pods', flex: 0.7, sortable: true },
+            { field: 'containerCount', headerName: 'containers', flex: 0.8, sortable: true },
+            { field: 'processCount', headerName: 'processes', flex: 0.8, sortable: true },
+            ...sharedStatusColumns,
+            sharedTimestampColumn,
+            { field: 'agentVersion', headerName: 'version', flex: 0.8, sortable: true },
+        ];
+    }
+
+    if (scope === 'namespace') {
+        return [
+            { field: 'namespace', headerName: 'namespace', flex: 1, sortable: true },
+            { field: 'service', headerName: 'service name', flex: 1.2, sortable: true },
+            { field: 'hostCount', headerName: 'hosts', flex: 0.7, sortable: true },
+            { field: 'podCount', headerName: 'pods', flex: 0.7, sortable: true },
+            { field: 'containerCount', headerName: 'containers', flex: 0.8, sortable: true },
+            { field: 'processCount', headerName: 'processes', flex: 0.8, sortable: true },
+            ...sharedStatusColumns,
+            sharedTimestampColumn,
+        ];
+    }
+
+    if (scope === 'host') {
+        return [
+            { field: 'service', headerName: 'service name', flex: 1, sortable: true },
+            { field: 'namespace', headerName: 'namespace', flex: 0.9, sortable: true },
+            { field: 'host', headerName: 'host name', flex: 1.1, sortable: true },
+            { field: 'pids', headerName: 'pids (if profiled)', flex: 1, sortable: false },
+            { field: 'ip', headerName: 'IP', flex: 0.9, sortable: true },
+            { field: 'commandType', headerName: 'command type', flex: 0.8, sortable: true },
+            { field: 'profilingStatus', headerName: 'profiling status', flex: 0.9, sortable: true },
+            sharedTimestampColumn,
+            {
+                field: 'profile',
+                headerName: 'profile',
+                flex: 1.2,
+                sortable: false,
+                renderCell: (params) => {
+                    const { host, service, commandType, profilingStatus } = params.row;
+                    if (commandType !== 'start' || profilingStatus !== 'active' || !host || !service) {
+                        return '';
+                    }
+
+                    return (
+                        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                            <a href={buildProfileUrl(host, service, 'flamegraph')} target="_blank" rel="noopener noreferrer">
+                                View Continuous Profile
+                            </a>
+                            <a href={buildProfileUrl(host, service, 'adhoc')} target="_blank" rel="noopener noreferrer">
+                                View Adhoc Profile
+                            </a>
+                        </Box>
+                    );
+                },
+            },
+        ];
+    }
+
+    if (scope === 'pod') {
+        return [
+            { field: 'podName', headerName: 'pod', flex: 1.2, sortable: true },
+            { field: 'namespace', headerName: 'namespace', flex: 0.9, sortable: true },
+            { field: 'service', headerName: 'service name', flex: 1, sortable: true },
+            { field: 'hostCount', headerName: 'hosts', flex: 0.7, sortable: true },
+            { field: 'containerCount', headerName: 'containers', flex: 0.8, sortable: true },
+            { field: 'processCount', headerName: 'processes', flex: 0.8, sortable: true },
+            ...sharedStatusColumns,
+            sharedTimestampColumn,
+        ];
+    }
+
+    if (scope === 'container') {
+        return [
+            { field: 'containerName', headerName: 'container', flex: 1.1, sortable: true },
+            { field: 'podName', headerName: 'pod', flex: 1, sortable: true },
+            { field: 'namespace', headerName: 'namespace', flex: 0.9, sortable: true },
+            { field: 'host', headerName: 'host', flex: 1, sortable: true },
+            { field: 'processCount', headerName: 'processes', flex: 0.8, sortable: true },
+            ...sharedStatusColumns,
+            sharedTimestampColumn,
+        ];
+    }
+
+    return [
+        { field: 'processName', headerName: 'process', flex: 1.1, sortable: true },
+        { field: 'pid', headerName: 'pid', flex: 0.6, sortable: true },
+        { field: 'containerName', headerName: 'container', flex: 1, sortable: true },
+        { field: 'podName', headerName: 'pod', flex: 1, sortable: true },
+        { field: 'namespace', headerName: 'namespace', flex: 0.9, sortable: true },
+        { field: 'host', headerName: 'host', flex: 1, sortable: true },
+        ...sharedStatusColumns,
+        sharedTimestampColumn,
+    ];
+};
+
+const formatRowForScope = (row, scope) => ({
+    id: readField(row, 'id'),
+    scope,
+    service: readField(row, 'serviceName', 'service_name'),
+    namespace: readField(row, 'namespace'),
+    host: readField(row, 'hostname'),
+    ip: readField(row, 'ipAddress', 'ip_address'),
+    podName: readField(row, 'podName', 'pod_name'),
+    containerName: readField(row, 'containerName', 'container_name'),
+    workloadName: readField(row, 'workloadName', 'workload_name'),
+    workloadKind: readField(row, 'workloadKind', 'workload_kind'),
+    processName: readField(row, 'processName', 'process_name'),
+    pid: readField(row, 'pid'),
+    pids: readField(row, 'pids', 'pids') || [],
+    activeHosts: readField(row, 'activeHosts', 'active_hosts'),
+    hostCount: readField(row, 'hostCount', 'host_count'),
+    namespaceCount: readField(row, 'namespaceCount', 'namespace_count'),
+    podCount: readField(row, 'podCount', 'pod_count'),
+    containerCount: readField(row, 'containerCount', 'container_count'),
+    processCount: readField(row, 'processCount', 'process_count'),
+    commandType: readField(row, 'commandType', 'command_type') || 'N/A',
+    profilingStatus: readField(row, 'profilingStatus', 'profiling_status') || 'stopped',
+    profilingMode: readField(row, 'profilingMode', 'profiling_mode') || 'N/A',
+    frequency: readField(row, 'frequency'),
+    profilerSummary: readField(row, 'profilerSummary', 'profiler_summary') || 'N/A',
+    heartbeatTimestamp: readField(row, 'heartbeatTimestamp', 'heartbeat_timestamp'),
+    agentVersion: readField(row, 'agentVersion', 'agent_version'),
+    runMode: readField(row, 'runMode', 'run_mode'),
+});
+
+const scopeEntityLabel = (scope) => {
+    const lookup = {
+        service: 'services',
+        namespace: 'namespaces',
+        host: 'hosts',
+        pod: 'pods',
+        container: 'containers',
+        process: 'processes',
+    };
+    return lookup[scope] || 'entities';
+};
+
+const rowDisplayName = (row, scope) => {
+    if (scope === 'service') return row.service;
+    if (scope === 'namespace') return `${row.namespace}`;
+    if (scope === 'host') return row.host;
+    if (scope === 'pod') return `${row.namespace}/${row.podName}`;
+    if (scope === 'container') return `${row.namespace}/${row.podName}/${row.containerName}`;
+    return `${row.processName} (${row.pid})`;
+};
+
+const buildTargetEntity = (row) => ({
+    id: row.id,
+    service_name: row.service,
+    namespace: row.namespace || undefined,
+    hostname: row.host || undefined,
+    ip_address: row.ip || undefined,
+    pod_name: row.podName || undefined,
+    container_name: row.containerName || undefined,
+    workload_name: row.workloadName || undefined,
+    workload_kind: row.workloadKind || undefined,
+    pid: row.pid || undefined,
+    process_name: row.processName || undefined,
+});
 
 const ProfilingStatusPage = () => {
+    const history = useHistory();
+    const location = useLocation();
+
+    const [activeScope, setActiveScope] = useState('service');
     const [rows, setRows] = useState([]);
+    const [scopeCounts, setScopeCounts] = useState({});
     const [loading, setLoading] = useState(false);
     const [selectionModel, setSelectionModel] = useState([]);
     const [activeCount, setActiveCount] = useState(0);
     const [totalCount, setTotalCount] = useState(0);
-    const [filters, setFilters] = useState({
-        service: '',
-        hostname: '',
-        pids: '',
-        ip: '',
-        commandType: '',
-        status: '',
-    });
-    const [appliedFilters, setAppliedFilters] = useState({
-        service: '',
-        hostname: '',
-        pids: '',
-        ip: '',
-        commandType: '',
-        status: '',
-    });
-    
-    // PerfSpect state
+    const [filters, setFilters] = useState(EMPTY_FILTERS);
+    const [appliedFilters, setAppliedFilters] = useState(EMPTY_FILTERS);
     const [enablePerfSpect, setEnablePerfSpect] = useState(false);
-    
-    // Profiling frequency state
     const [profilingFrequency, setProfilingFrequency] = useState(DEFAULT_PROFILING_FREQUENCY);
-    
-    // Max processes state
     const [maxProcesses, setMaxProcesses] = useState(DEFAULT_MAX_PROCESSES);
-    
-    // Profiling mode state (Ad Hoc vs Continuous)
-    const [profilingMode, setProfilingMode] = useState('continuous'); // 'adhoc' or 'continuous'
-    
-    // Duration state
+    const [profilingMode, setProfilingMode] = useState('continuous');
     const [duration, setDuration] = useState(DEFAULT_DURATION);
-    
-    // Profiler configurations state
     const [profilerConfigs, setProfilerConfigs] = useState({
-        perf: {
-            mode: 'enabled_restricted', // 'enabled_restricted', 'enabled_aggressive', 'disabled'
-            events: ['cpu-cycles'] // Array of events: 'cpu-cycles', 'instructions', 'cache-misses', etc.
-        },
-        async_profiler: {
-            enabled: true,
-            time: 'cpu' // 'cpu' or 'wall'
-        },
-        pyperf: 'enabled', // 'enabled', 'disabled'
-        pyspy: 'enabled_fallback', // 'enabled_fallback', 'enabled', 'disabled'
-        rbspy: 'disabled', // 'enabled', 'disabled'
-        phpspy: 'disabled', // 'enabled', 'disabled'
-        dotnet_trace: 'disabled', // 'enabled', 'disabled'
-        nodejs_perf: 'enabled', // 'enabled', 'disabled'
+        perf: { mode: 'enabled_restricted', events: ['cpu-cycles'] },
+        async_profiler: { enabled: true, time: 'cpu' },
+        pyperf: 'enabled',
+        pyspy: 'enabled_fallback',
+        rbspy: 'disabled',
+        phpspy: 'disabled',
+        dotnet_trace: 'disabled',
+        nodejs_perf: 'enabled',
     });
-
-    // Confirmation dialog state
     const [confirmationDialog, setConfirmationDialog] = useState({
         open: false,
         action: null,
         selectedRows: [],
         serviceGroups: {},
     });
-    
-    // Dry-run validation state
     const [dryRunValidation, setDryRunValidation] = useState({
         isValidating: false,
         isValid: false,
         errors: [],
     });
-    
-    const history = useHistory();
-    const location = useLocation();
 
-    const fetchProfilingStatus = useCallback((filterParams) => {
+    const columns = useMemo(() => getScopeColumns(activeScope), [activeScope]);
+
+    const fetchProfilingStatus = useCallback((filterParams, scope = activeScope) => {
         setLoading(true);
-
-        // Build query parameters
         const params = new URLSearchParams();
+        params.append('scope', scope);
 
-        if (filterParams.service) {
-            params.append('service_name', filterParams.service);
-        }
-        if (filterParams.hostname) {
-            params.append('hostname', filterParams.hostname);
-        }
-        if (filterParams.pids) {
-            params.append('pids', filterParams.pids);
-        }
-        if (filterParams.ip) {
-            params.append('ip_address', filterParams.ip);
-        }
-        if (filterParams.commandType) {
-            params.append('command_type', filterParams.commandType);
-        }
-        if (filterParams.status) {
-            params.append('profiling_status', filterParams.status);
-        }
+        if (filterParams.service) params.append('service_name', filterParams.service);
+        if (filterParams.hostname) params.append('hostname', filterParams.hostname);
+        if (filterParams.pids) params.append('pids', filterParams.pids);
+        if (filterParams.ip) params.append('ip_address', filterParams.ip);
+        if (filterParams.namespace) params.append('namespace', filterParams.namespace);
+        if (filterParams.podName) params.append('pod_name', filterParams.podName);
+        if (filterParams.containerName) params.append('container_name', filterParams.containerName);
+        if (filterParams.processName) params.append('process_name', filterParams.processName);
+        if (filterParams.commandType) params.append('command_type', filterParams.commandType);
+        if (filterParams.status) params.append('profiling_status', filterParams.status);
 
-        const url = params.toString()
-            ? `${DATA_URLS.GET_PROFILING_HOST_STATUS}?${params.toString()}`
-            : DATA_URLS.GET_PROFILING_HOST_STATUS;
-
-        fetch(url)
+        fetch(`${DATA_URLS.GET_PROFILING_WORKLOAD_STATUS}?${params.toString()}`)
             .then((res) => res.json())
             .then((data) => {
-                // Handle new response structure with hosts, active_count, and total_count
-                const hosts = data.hosts || data; // Fallback to data if old format
-                const active = data.active_count || hosts.length;
-                const total = data.total_count || hosts.length;
-                
-                setRows(
-                    hosts.map((row) => ({
-                        id: row.id,
-                        service: row.service_name,
-                        host: row.hostname,
-                        pids: row.pids,
-                        ip: row.ip_address,
-                        commandType: row.command_type || 'N/A',
-                        status: row.profiling_status,
-                        heartbeat_timestamp: row.heartbeat_timestamp,
-                    }))
-                );
-                setActiveCount(active);
-                setTotalCount(total);
+                const normalizedRows = (data.rows || []).map((row) => formatRowForScope(row, scope));
+                setRows(normalizedRows);
+                setScopeCounts(data.tabCounts || data.tab_counts || {});
+                setActiveCount(data.activeHosts || data.active_hosts || 0);
+                setTotalCount(data.totalCount || data.total_count || normalizedRows.length);
                 setLoading(false);
             })
             .catch(() => setLoading(false));
-    }, []); // No dependencies needed since it takes filterParams as argument
+    }, [activeScope]);
 
-    // Initialize filters from URL parameters for direct URL visits (shareable links)
-    useEffect(() => {
-        const searchParams = queryString.parse(location.search);
-        const hasFilterParams = ['service', 'hostname', 'pids', 'ip', 'commandType', 'status'].some(
-            param => searchParams[param]
-        );
-        
-        // Only initialize from URL if there are actual filter parameters
-        if (hasFilterParams) {
-            const urlFilters = {
-                service: searchParams.service || '',
-                hostname: searchParams.hostname || '',
-                pids: searchParams.pids || '',
-                ip: searchParams.ip || '',
-                commandType: searchParams.commandType || '',
-                status: searchParams.status || '',
-            };
-            setFilters(urlFilters);
-            setAppliedFilters(urlFilters);
-            // Automatically fetch data with URL filters on page load
-            fetchProfilingStatus(urlFilters);
-        } else {
-            // No URL params, fetch all data
-            const emptyFilters = {
-                service: '',
-                hostname: '',
-                pids: '',
-                ip: '',
-                commandType: '',
-                status: '',
-            };
-            fetchProfilingStatus(emptyFilters);
-        }
-        
-        // Clean up profile-specific parameters if they exist (mixed URLs)
-        const profileParams = ['gtab', 'view', 'time', 'startTime', 'endTime', 'filter', 'rt', 'rtms', 'p', 'pm', 'wt', 'wp', 'search', 'fullscreen'];
-        const hasProfileParams = profileParams.some(param => searchParams[param]);
-        
-        if (hasProfileParams) {
-            // Remove only profile params, keep filter params
-            const cleanedParams = { ...searchParams };
-            profileParams.forEach(param => {
-                delete cleanedParams[param];
-            });
-            history.replace({ search: queryString.stringify(cleanedParams) });
-        }
-    }, [fetchProfilingStatus, history, location.search]); // Add dependencies
-
-    // Auto-refresh every 30 seconds for dynamic profiling
-    useEffect(() => {
-        const refreshInterval = setInterval(() => {
-            // Refresh with current applied filters
-            fetchProfilingStatus(appliedFilters);
-        }, 30000); // 30 seconds
-
-        // Cleanup interval on component unmount
-        return () => clearInterval(refreshInterval);
-    }, [appliedFilters, fetchProfilingStatus]); // Re-create interval when filters change
-
-    // Update URL when filters change (with focus preservation)
-    const updateURL = useCallback(
-        (newFilters) => {
-            // Use replace instead of push to avoid navigation history buildup
-            // and reduce re-render impact on focus
-            const searchParams = {};
-
-            // Add new filter parameters
-            Object.keys(newFilters).forEach((key) => {
-                if (newFilters[key]) {
-                    searchParams[key] = newFilters[key];
-                }
-            });
-
-            const newSearch = queryString.stringify(searchParams);
-            
-            // Use replace instead of push to minimize focus disruption
-            if (newSearch === '') {
-                history.replace('/profiling');
-            } else {
-                history.replace({ pathname: '/profiling', search: newSearch });
+    const updateURL = useCallback((scope, nextFilters) => {
+        const searchParams = { scope };
+        Object.keys(nextFilters).forEach((key) => {
+            if (nextFilters[key]) {
+                searchParams[key] = nextFilters[key];
             }
-        },
-        [history]
-    );
+        });
+        history.replace({ pathname: '/profiling', search: queryString.stringify(searchParams) });
+    }, [history]);
 
-    // Function to update individual filter (optimized for focus preservation)
-    const updateFilter = useCallback((field, value) => {
-        setFilters(prev => ({ ...prev, [field]: value }));
-    }, []); // Stable function reference
-
-    // Apply filters function
     const applyFilters = useCallback(() => {
         setAppliedFilters(filters);
-        fetchProfilingStatus(filters);
-        updateURL(filters);
-    }, [filters, fetchProfilingStatus, updateURL]);
+        setSelectionModel([]);
+        fetchProfilingStatus(filters, activeScope);
+        updateURL(activeScope, filters);
+    }, [activeScope, fetchProfilingStatus, filters, updateURL]);
 
-    // Clear all filters function
     const clearAllFilters = useCallback(() => {
-        const emptyFilters = {
-            service: '',
-            hostname: '',
-            pids: '',
-            ip: '',
-            commandType: '',
-            status: '',
+        setFilters(EMPTY_FILTERS);
+        setAppliedFilters(EMPTY_FILTERS);
+        setSelectionModel([]);
+        fetchProfilingStatus(EMPTY_FILTERS, activeScope);
+        updateURL(activeScope, EMPTY_FILTERS);
+    }, [activeScope, fetchProfilingStatus, updateURL]);
+
+    const updateFilter = useCallback((field, value) => {
+        setFilters((prev) => ({ ...prev, [field]: value }));
+    }, []);
+
+    useEffect(() => {
+        const searchParams = queryString.parse(location.search);
+        const scope = searchParams.scope || 'service';
+        const urlFilters = {
+            service: searchParams.service || '',
+            hostname: searchParams.hostname || '',
+            pids: searchParams.pids || '',
+            ip: searchParams.ip || '',
+            namespace: searchParams.namespace || '',
+            podName: searchParams.podName || '',
+            containerName: searchParams.containerName || '',
+            processName: searchParams.processName || '',
+            commandType: searchParams.commandType || '',
+            status: searchParams.status || '',
         };
-        setFilters(emptyFilters);
-        setAppliedFilters(emptyFilters);
-        fetchProfilingStatus(emptyFilters);
-        updateURL(emptyFilters);
-    }, [fetchProfilingStatus, updateURL]);
+        setActiveScope(scope);
+        setFilters(urlFilters);
+        setAppliedFilters(urlFilters);
+        fetchProfilingStatus(urlFilters, scope);
+    }, [fetchProfilingStatus, location.search]);
 
-    // Bulk Start/Stop handlers
-    function handleBulkAction(action) {
-        const selectedRows = rows.filter((row) => selectionModel.includes(row.id));
+    useEffect(() => {
+        const refreshInterval = setInterval(() => {
+            fetchProfilingStatus(appliedFilters, activeScope);
+        }, 30000);
+        return () => clearInterval(refreshInterval);
+    }, [activeScope, appliedFilters, fetchProfilingStatus]);
 
-        // Group selected rows by service name
-        const serviceGroups = selectedRows.reduce((groups, row) => {
+    const handleScopeChange = (_, nextScope) => {
+        setActiveScope(nextScope);
+        setSelectionModel([]);
+        fetchProfilingStatus(appliedFilters, nextScope);
+        updateURL(nextScope, appliedFilters);
+    };
+
+    const buildRequests = useCallback((action, selectedRows) => {
+        const grouped = selectedRows.reduce((groups, row) => {
             if (!groups[row.service]) {
                 groups[row.service] = [];
             }
-            groups[row.service].push(row.host);
+            groups[row.service].push(row);
             return groups;
         }, {});
 
-        // Show confirmation dialog
-        setConfirmationDialog({
-            open: true,
-            action,
-            selectedRows,
-            serviceGroups,
-        });
+        const requests = Object.entries(grouped).map(([serviceName, serviceRows]) => {
+            const targetScope = activeScope;
+            const targetHosts = targetScope === 'host'
+                ? serviceRows.reduce((hostMap, row) => {
+                    hostMap[row.host] = null;
+                    return hostMap;
+                }, {})
+                : undefined;
 
-        // Trigger dry-run validation when dialog opens
-        executeDryRun(action, serviceGroups);
-    }
-
-    // Execute dry-run validation
-    function executeDryRun(action, serviceGroups) {
-        setDryRunValidation({
-            isValidating: true,
-            isValid: false,
-            errors: [],
-        });
-
-        // Create bulk request with all services
-        const requests = Object.entries(serviceGroups).map(([serviceName, hosts]) => {
-            const target_host = hosts.reduce((hostObj, host) => {
-                hostObj[host] = null;
-                return hostObj;
-            }, {});
-
-            const request = {
+            return {
                 service_name: serviceName,
                 request_type: action,
                 continuous: profilingMode === 'continuous',
                 duration: profilingMode === 'continuous' ? 60 : duration,
                 frequency: profilingFrequency,
                 profiling_mode: 'cpu',
-                target_hosts: target_host,
+                target_scope: targetScope,
+                target_hosts: targetHosts,
+                target_entities: serviceRows.map((row) => buildTargetEntity(row)),
+                stop_level: action === 'stop' ? (['service', 'host'].includes(targetScope) ? 'host' : 'process') : undefined,
                 additional_args: {
                     enable_perfspect: enablePerfSpect,
                     profiler_configs: profilerConfigs,
                     max_processes: maxProcesses,
                 },
             };
-
-            if (action === 'stop') {
-                request.stop_level = 'host';
-            }
-
-            return request;
         });
 
-        // Use bulk endpoint with dry_run
-        const bulkRequest = {
-            requests: requests,
-            dry_run: true,
-        };
+        return { grouped, requests };
+    }, [activeScope, duration, enablePerfSpect, maxProcesses, profilerConfigs, profilingFrequency, profilingMode]);
+
+    const executeDryRun = useCallback((action, selectedRows) => {
+        const { requests } = buildRequests(action, selectedRows);
+        setDryRunValidation({ isValidating: true, isValid: false, errors: [] });
 
         fetch(DATA_URLS.POST_PROFILING_REQUEST_BULK, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(bulkRequest),
+            body: JSON.stringify({ requests, dry_run: true }),
         })
-            .then(res => {
+            .then((res) => {
                 if (!res.ok) {
-                    return res.json().then(errData => {
-                        // Extract detailed validation messages
+                    return res.json().then((errData) => {
                         if (errData.detail && Array.isArray(errData.detail)) {
-                            const messages = errData.detail.map(err => err.msg || JSON.stringify(err)).join('; ');
-                            throw new Error(messages);
-                        } else if (typeof errData.detail === 'string') {
-                            throw new Error(errData.detail);
-                        } else {
-                            throw new Error(`Validation failed`);
+                            throw new Error(errData.detail.map((err) => err.msg || JSON.stringify(err)).join('; '));
                         }
-                    }).catch(err => {
-                        // If error is already thrown from above, re-throw it
-                        if (err.message) throw err;
-                        throw new Error(`Validation failed with status ${res.status}`);
+                        throw new Error(errData.detail || `Validation failed with status ${res.status}`);
                     });
                 }
                 return res.json();
             })
             .then((bulkResponse) => {
-                // Process bulk response to extract errors
-                const errors = [];
-
-                bulkResponse.results.forEach(result => {
-                    if (!result.success) {
-                        errors.push(`${result.service_name}: ${result.error}`);
-                    }
-                });
-
+                const errors = (bulkResponse.results || [])
+                    .filter((result) => !result.success)
+                    .map((result) => `${result.service_name}: ${result.error}`);
                 setDryRunValidation({
                     isValidating: false,
-                    isValid: bulkResponse.failed_count === 0,
-                    errors: errors,
+                    isValid: (bulkResponse.failed_count || 0) === 0,
+                    errors,
                 });
             })
-            .catch(error => {
-                // Handle global validation errors (e.g., capacity exceeded)
+            .catch((error) => {
                 setDryRunValidation({
                     isValidating: false,
                     isValid: false,
                     errors: [error.message],
                 });
             });
-    }
+    }, [buildRequests]);
 
-    // Execute the actual profiling action after confirmation
-    function executeProfilingAction() {
-        const { action, serviceGroups } = confirmationDialog;
-
-        // Create bulk request with all services
-        const requests = Object.entries(serviceGroups).map(([serviceName, hosts]) => {
-            const target_host = hosts.reduce((hostObj, host) => {
-                hostObj[host] = null;
-                return hostObj;
-            }, {});
-
-            const request = {
-                service_name: serviceName,
-                request_type: action,
-                continuous: profilingMode === 'continuous',
-                duration: profilingMode === 'continuous' ? 60 : duration,
-                frequency: profilingFrequency, // Use frequency from UI
-                profiling_mode: 'cpu', // Default profiling mode, can't be adjusted yet
-                target_hosts: target_host,
-                additional_args: {
-                    enable_perfspect: enablePerfSpect, // Include PerfSpect setting
-                    profiler_configs: profilerConfigs, // Include all profiler configurations
-                    max_processes: maxProcesses, // Include max processes setting
-                },
-            };
-
-            // append 'stop_level: host' when action is 'stop'
-            if (action === 'stop') {
-                request.stop_level = 'host';
-            }
-
-            return request;
+    const handleBulkAction = (action) => {
+        const selectedRows = rows.filter((row) => selectionModel.includes(row.id));
+        const { grouped } = buildRequests(action, selectedRows);
+        setConfirmationDialog({
+            open: true,
+            action,
+            selectedRows,
+            serviceGroups: grouped,
         });
+        executeDryRun(action, selectedRows);
+    };
 
-        // Use bulk endpoint
-        const bulkRequest = {
-            requests: requests,
-            dry_run: false,
-        };
+    const executeProfilingAction = () => {
+        const { action, selectedRows } = confirmationDialog;
+        const { requests } = buildRequests(action, selectedRows);
 
-        // Close dialog and execute bulk request
         setConfirmationDialog({ open: false, action: null, selectedRows: [], serviceGroups: {} });
-        setDryRunValidation({ isValidating: false, isValid: false, errors: [] }); // Reset dry-run state
-        
+        setDryRunValidation({ isValidating: false, isValid: false, errors: [] });
+
         fetch(DATA_URLS.POST_PROFILING_REQUEST_BULK, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(bulkRequest),
+            body: JSON.stringify({ requests, dry_run: false }),
         }).then(() => {
-            // Maintain current filter state when refreshing
-            fetchProfilingStatus(appliedFilters);
-            setSelectionModel([]); // Clear all checkboxes after API requests complete
-            setEnablePerfSpect(false); // Reset PerfSpect checkbox after action completes
-            // Note: Keep profiling frequency as is - user may want to reuse the same frequency
+            fetchProfilingStatus(appliedFilters, activeScope);
+            setSelectionModel([]);
+            setEnablePerfSpect(false);
         });
-    }
+    };
 
-    // Close confirmation dialog without action
-    function handleDialogClose() {
+    const handleDialogClose = () => {
         setConfirmationDialog({ open: false, action: null, selectedRows: [], serviceGroups: {} });
-        setDryRunValidation({ isValidating: false, isValid: false, errors: [] }); // Reset dry-run state
-    }
+        setDryRunValidation({ isValidating: false, isValid: false, errors: [] });
+    };
 
     return (
         <Box sx={{ backgroundColor: 'white.main', height: '100%' }}>
-            <ProfilingHeader 
-                filters={filters} 
-                updateFilter={updateFilter} 
+            <ProfilingHeader
+                filters={filters}
+                updateFilter={updateFilter}
                 isLoading={loading}
                 onApplyFilters={applyFilters}
                 onClearFilters={clearAllFilters}
             />
 
-            <Box
-                sx={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                }}>
+            <Box sx={{ px: 4, pt: 2 }}>
+                <Tabs value={activeScope} onChange={handleScopeChange} variant="scrollable" scrollButtons="auto">
+                    {SCOPES.map((scope) => (
+                        <Tab
+                            key={scope.id}
+                            value={scope.id}
+                            label={`${scope.label} ${scopeCounts[scope.id] ? scopeCounts[scope.id] : ''}`.trim()}
+                        />
+                    ))}
+                </Tabs>
+            </Box>
+
+            <Box sx={{ display: 'flex', flexDirection: 'column' }}>
                 <ProfilingTopPanel
                     selectionModel={selectionModel}
                     handleBulkAction={handleBulkAction}
-                    fetchProfilingStatus={fetchProfilingStatus}
+                    fetchProfilingStatus={(scopeFilters) => fetchProfilingStatus(scopeFilters, activeScope)}
                     filters={appliedFilters}
                     loading={loading}
                     activeCount={activeCount}
                     totalCount={totalCount}
+                    activeLabel="active hosts"
+                    totalLabel={scopeEntityLabel(activeScope)}
                     clearAllFilters={clearAllFilters}
                     enablePerfSpect={enablePerfSpect}
                     onPerfSpectChange={setEnablePerfSpect}
@@ -588,7 +565,6 @@ const ProfilingStatusPage = () => {
                     onProfilerConfigsChange={setProfilerConfigs}
                 />
 
-                {/* Data Table */}
                 <Box sx={{ p: 4, '& .MuiDataGrid-root': { border: 'none' } }}>
                     <MuiTable
                         columns={columns}
@@ -600,29 +576,17 @@ const ProfilingStatusPage = () => {
                         checkboxSelection
                         onSelectionModelChange={setSelectionModel}
                         selectionModel={selectionModel}
-                        initialState={{
-                            sorting: {
-                                sortModel: [{ field: 'host', sort: 'asc' }],
-                            },
-                        }}
                     />
                 </Box>
             </Box>
 
-            {/* Confirmation Dialog */}
-            <Dialog
-                open={confirmationDialog.open}
-                onClose={handleDialogClose}
-                maxWidth="md"
-                fullWidth
-            >
+            <Dialog open={confirmationDialog.open} onClose={handleDialogClose} maxWidth="md" fullWidth>
                 <DialogTitle>
-                    <Typography variant="h6" component="div">
+                    <Typography variant="h6">
                         Confirm {confirmationDialog.action === 'start' ? 'Start' : 'Stop'} Profiling
                     </Typography>
                 </DialogTitle>
                 <DialogContent>
-                    {/* Validation Status */}
                     {dryRunValidation.isValidating && (
                         <Box sx={{ mb: 2, p: 2, backgroundColor: '#f5f5f5', borderRadius: 1 }}>
                             <Typography variant="body2" color="text.secondary">
@@ -630,7 +594,6 @@ const ProfilingStatusPage = () => {
                             </Typography>
                         </Box>
                     )}
-                    
                     {!dryRunValidation.isValidating && dryRunValidation.isValid && (
                         <Box sx={{ mb: 2, p: 2, backgroundColor: '#e8f5e9', borderRadius: 1 }}>
                             <Typography variant="body2" color="success.dark">
@@ -638,7 +601,6 @@ const ProfilingStatusPage = () => {
                             </Typography>
                         </Box>
                     )}
-                    
                     {!dryRunValidation.isValidating && !dryRunValidation.isValid && dryRunValidation.errors.length > 0 && (
                         <Box sx={{ mb: 2, p: 2, backgroundColor: '#ffebee', borderRadius: 1 }}>
                             <Typography variant="body2" color="error.dark" sx={{ fontWeight: 600, mb: 1 }}>
@@ -653,24 +615,23 @@ const ProfilingStatusPage = () => {
                     )}
 
                     <Typography variant="body1" sx={{ mb: 2 }}>
-                        Are you sure you want to <strong>{confirmationDialog.action}</strong> profiling for the following hosts?
+                        Are you sure you want to <strong>{confirmationDialog.action}</strong> profiling for the selected {scopeEntityLabel(activeScope)}?
                     </Typography>
-                    
-                    {/* Selected Hosts Summary */}
+
                     <Box sx={{ mb: 3 }}>
                         <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: 600 }}>
-                            Selected Hosts ({confirmationDialog.selectedRows.length}):
+                            Selected {scopeEntityLabel(activeScope)} ({confirmationDialog.selectedRows.length}):
                         </Typography>
-                        {Object.entries(confirmationDialog.serviceGroups).map(([serviceName, hosts]) => (
+                        {Object.entries(confirmationDialog.serviceGroups).map(([serviceName, serviceRows]) => (
                             <Box key={serviceName} sx={{ mb: 2 }}>
                                 <Typography variant="body2" sx={{ fontWeight: 500, mb: 0.5 }}>
                                     {serviceName}:
                                 </Typography>
                                 <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-                                    {hosts.map((host) => (
+                                    {serviceRows.map((row) => (
                                         <Chip
-                                            key={host}
-                                            label={host}
+                                            key={row.id}
+                                            label={rowDisplayName(row, activeScope)}
                                             size="small"
                                             variant="outlined"
                                             sx={{
@@ -684,16 +645,13 @@ const ProfilingStatusPage = () => {
                         ))}
                     </Box>
 
-                    {/* Configuration Summary (only for start action) */}
                     {confirmationDialog.action === 'start' && (
                         <>
                             <Divider sx={{ my: 2 }} />
                             <Typography variant="subtitle2" sx={{ mb: 2, fontWeight: 600 }}>
                                 Profiling Configuration:
                             </Typography>
-                            
                             <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 2 }}>
-                                {/* Basic Settings */}
                                 <Box>
                                     <Typography variant="body2" sx={{ fontWeight: 500, mb: 1 }}>
                                         Basic Settings:
@@ -705,8 +663,6 @@ const ProfilingStatusPage = () => {
                                     <Typography variant="body2">• Duration: {profilingMode === 'continuous' ? 60 : duration} seconds</Typography>
                                     <Typography variant="body2">• Mode: CPU profiling</Typography>
                                 </Box>
-
-                                {/* Profiler Settings */}
                                 <Box>
                                     <Typography variant="body2" sx={{ fontWeight: 500, mb: 1 }}>
                                         Profiler Settings:
@@ -716,7 +672,7 @@ const ProfilingStatusPage = () => {
                                         profilerConfigs.perf?.mode === 'enabled_aggressive' ? 'Enabled (Aggressive)' : 'Disabled'
                                     }</Typography>
                                     <Typography variant="body2">• Java Async Profiler: {
-                                        profilerConfigs.async_profiler?.enabled 
+                                        profilerConfigs.async_profiler?.enabled
                                             ? `Enabled (${profilerConfigs.async_profiler.time === 'wall' ? 'Wall Time' : 'CPU Time'})`
                                             : 'Disabled'
                                     }</Typography>
@@ -735,11 +691,9 @@ const ProfilingStatusPage = () => {
                     )}
                 </DialogContent>
                 <DialogActions>
-                    <Button onClick={handleDialogClose} color="primary">
-                        Cancel
-                    </Button>
-                    <Button 
-                        onClick={executeProfilingAction} 
+                    <Button onClick={handleDialogClose}>Cancel</Button>
+                    <Button
+                        onClick={executeProfilingAction}
                         color={confirmationDialog.action === 'start' ? 'success' : 'error'}
                         variant="contained"
                         disabled={dryRunValidation.isValidating || !dryRunValidation.isValid}

--- a/src/gprofiler/frontend/src/components/console/header/ProfilingHeader.jsx
+++ b/src/gprofiler/frontend/src/components/console/header/ProfilingHeader.jsx
@@ -57,7 +57,7 @@ const ProfilingHeader = ({ filters, updateFilter, isLoading = false, onApplyFilt
                                 xs: '1fr', 
                                 sm: '1fr 1fr', 
                                 md: '1fr 1fr 1fr', 
-                                lg: '1fr 1fr 1fr 1fr 1fr 1fr' 
+                                lg: '1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr'
                             },
                             width: '100%',
                             gap: { xs: 2, sm: 2, md: 3 },
@@ -157,6 +157,122 @@ const ProfilingHeader = ({ filters, updateFilter, isLoading = false, onApplyFilt
                     value={filters.ip}
                     onChange={(e) => updateFilter('ip', e.target.value)}
                     placeholder='Filter by IP...'
+                    disabled={isLoading}
+                    fullWidth
+                    sx={{
+                        backgroundColor: 'white !important',
+                        borderRadius: '4px',
+                        boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.1)',
+                        '& .MuiOutlinedInput-root': {
+                            backgroundColor: 'white !important',
+                            '& fieldset': {
+                                borderColor: 'rgba(0, 0, 0, 0.23)',
+                            },
+                            '&:hover fieldset': {
+                                borderColor: 'rgba(0, 0, 0, 0.87)',
+                            },
+                        },
+                        '& .MuiInputBase-input': {
+                            backgroundColor: 'white !important',
+                        },
+                    }}
+                />
+
+                {/* Namespace Filter */}
+                <TextField
+                    label='Namespace'
+                    variant='outlined'
+                    size='small'
+                    value={filters.namespace}
+                    onChange={(e) => updateFilter('namespace', e.target.value)}
+                    placeholder='Filter by namespace...'
+                    disabled={isLoading}
+                    fullWidth
+                    sx={{
+                        backgroundColor: 'white !important',
+                        borderRadius: '4px',
+                        boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.1)',
+                        '& .MuiOutlinedInput-root': {
+                            backgroundColor: 'white !important',
+                            '& fieldset': {
+                                borderColor: 'rgba(0, 0, 0, 0.23)',
+                            },
+                            '&:hover fieldset': {
+                                borderColor: 'rgba(0, 0, 0, 0.87)',
+                            },
+                        },
+                        '& .MuiInputBase-input': {
+                            backgroundColor: 'white !important',
+                        },
+                    }}
+                />
+
+                {/* Pod Filter */}
+                <TextField
+                    label='Pod Name'
+                    variant='outlined'
+                    size='small'
+                    value={filters.podName}
+                    onChange={(e) => updateFilter('podName', e.target.value)}
+                    placeholder='Filter by pod...'
+                    disabled={isLoading}
+                    fullWidth
+                    sx={{
+                        backgroundColor: 'white !important',
+                        borderRadius: '4px',
+                        boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.1)',
+                        '& .MuiOutlinedInput-root': {
+                            backgroundColor: 'white !important',
+                            '& fieldset': {
+                                borderColor: 'rgba(0, 0, 0, 0.23)',
+                            },
+                            '&:hover fieldset': {
+                                borderColor: 'rgba(0, 0, 0, 0.87)',
+                            },
+                        },
+                        '& .MuiInputBase-input': {
+                            backgroundColor: 'white !important',
+                        },
+                    }}
+                />
+
+                {/* Container Filter */}
+                <TextField
+                    label='Container Name'
+                    variant='outlined'
+                    size='small'
+                    value={filters.containerName}
+                    onChange={(e) => updateFilter('containerName', e.target.value)}
+                    placeholder='Filter by container...'
+                    disabled={isLoading}
+                    fullWidth
+                    sx={{
+                        backgroundColor: 'white !important',
+                        borderRadius: '4px',
+                        boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.1)',
+                        '& .MuiOutlinedInput-root': {
+                            backgroundColor: 'white !important',
+                            '& fieldset': {
+                                borderColor: 'rgba(0, 0, 0, 0.23)',
+                            },
+                            '&:hover fieldset': {
+                                borderColor: 'rgba(0, 0, 0, 0.87)',
+                            },
+                        },
+                        '& .MuiInputBase-input': {
+                            backgroundColor: 'white !important',
+                        },
+                    }}
+                />
+
+                {/* Process Filter */}
+                <TextField
+                    label='Process Name'
+                    variant='outlined'
+                    size='small'
+                    value={filters.processName}
+                    onChange={(e) => updateFilter('processName', e.target.value)}
+                    placeholder='Filter by process...'
                     disabled={isLoading}
                     fullWidth
                     sx={{

--- a/src/gprofiler/frontend/src/components/console/header/ProfilingTopPanel.jsx
+++ b/src/gprofiler/frontend/src/components/console/header/ProfilingTopPanel.jsx
@@ -20,6 +20,8 @@ const ProfilingTopPanel = ({
     loading,
     activeCount,
     totalCount,
+    activeLabel = 'active hosts',
+    totalLabel = 'hosts',
     clearAllFilters,
     enablePerfSpect,
     onPerfSpectChange,
@@ -376,7 +378,7 @@ const ProfilingTopPanel = ({
                             </Button>
                         )}
                         <Typography variant='body2' color='text.secondary' sx={{ fontSize: '0.8rem' }}>
-                            {activeCount} active hosts of {totalCount} hosts
+                            {activeCount} {activeLabel} of {totalCount} {totalLabel}
                         </Typography>
                     </Flexbox>
                 </Flexbox>

--- a/src/gprofiler/frontend/src/components/console/header/ProfilingTopPanel.jsx
+++ b/src/gprofiler/frontend/src/components/console/header/ProfilingTopPanel.jsx
@@ -1,16 +1,48 @@
-import { Box, Button, Divider, Typography, FormControlLabel, Checkbox, Tooltip, TextField, Radio, RadioGroup, Accordion, AccordionSummary, AccordionDetails } from '@mui/material';
+import {
+    Accordion,
+    AccordionDetails,
+    AccordionSummary,
+    Box,
+    Button,
+    Checkbox,
+    FormControlLabel,
+    Paper,
+    Radio,
+    RadioGroup,
+    TextField,
+    Tooltip,
+    Typography,
+} from '@mui/material';
 import React from 'react';
 
-import { COLORS } from '../../../theme/colors';
-import Flexbox from '../../common/layout/Flexbox';
+import Icon from '../../common/icon/Icon';
+import { ICONS_NAMES } from '../../common/icon/iconsData';
 
-// Constants
-const DEFAULT_PROFILING_FREQUENCY = 11; // Hz - industry standard for low overhead
-const DEFAULT_MAX_PROCESSES = 10;
-const DEFAULT_DURATION = 60; // seconds
-const CONTINUOUS_MODE_DURATION = 60; // Fixed duration for continuous mode
+const ACTION_COLORS = {
+    start: { bg: '#16a34a', hover: '#15803d' },
+    stop: { bg: '#dc2626', hover: '#b91c1c' },
+    save: { bg: '#2563eb', hover: '#1d4ed8' },
+};
 
-const PanelDivider = () => <Divider orientation='vertical' sx={{ borderColor: 'grey.dark', opacity: 0.1 }} flexItem />;
+const fieldSx = {
+    width: '110px',
+    '& .MuiOutlinedInput-root': {
+        height: '36px',
+        fontSize: '0.875rem',
+    },
+};
+
+const Label = ({ children }) => (
+    <Typography variant='body2' sx={{ fontSize: '0.875rem', fontWeight: 500, mb: 0.5 }}>
+        {children}
+    </Typography>
+);
+
+const Helper = ({ children }) => (
+    <Typography variant='caption' sx={{ color: 'text.secondary', display: 'block', mt: 0.5 }}>
+        {children}
+    </Typography>
+);
 
 const ProfilingTopPanel = ({
     selectionModel,
@@ -18,11 +50,6 @@ const ProfilingTopPanel = ({
     fetchProfilingStatus,
     filters,
     loading,
-    activeCount,
-    totalCount,
-    activeLabel = 'active hosts',
-    totalLabel = 'hosts',
-    clearAllFilters,
     enablePerfSpect,
     onPerfSpectChange,
     profilingFrequency,
@@ -35,49 +62,37 @@ const ProfilingTopPanel = ({
     onDurationChange,
     profilerConfigs,
     onProfilerConfigsChange,
+    onSaveConfiguration,
 }) => {
-    const hasActiveFilters = Object.values(filters).some((value) => value);
+    const selectedCount = selectionModel.length;
+    const isAdhoc = profilingMode === 'adhoc';
 
-    // Helper function to handle profiler config changes
     const handleProfilerConfigChange = (profilerKey, value) => {
-        onProfilerConfigsChange(prev => ({
-            ...prev,
-            [profilerKey]: value
-        }));
+        onProfilerConfigsChange((prev) => ({ ...prev, [profilerKey]: value }));
     };
 
-    // Helper function to handle async profiler nested config changes
     const handleAsyncProfilerConfigChange = (field, value) => {
-        onProfilerConfigsChange(prev => ({
+        onProfilerConfigsChange((prev) => ({
             ...prev,
-            async_profiler: {
-                ...prev.async_profiler,
-                [field]: value
-            }
+            async_profiler: { ...prev.async_profiler, [field]: value },
         }));
     };
 
-    // Helper function to handle perf profiler nested config changes
     const handlePerfProfilerConfigChange = (field, value) => {
-        onProfilerConfigsChange(prev => ({
+        onProfilerConfigsChange((prev) => ({
             ...prev,
-            perf: {
-                ...prev.perf,
-                [field]: value
-            }
+            perf: { ...prev.perf, [field]: value },
         }));
     };
 
-    // Helper function to toggle perf events
     const handlePerfEventToggle = (eventName, isChecked) => {
         const currentEvents = profilerConfigs.perf?.events || [];
         const newEvents = isChecked
             ? [...currentEvents, eventName]
-            : currentEvents.filter(ev => ev !== eventName);
+            : currentEvents.filter((ev) => ev !== eventName);
         handlePerfProfilerConfigChange('events', newEvents);
     };
 
-    // Perf event configuration
     const perfEvents = [
         { value: 'cpu-cycles', label: 'CPU Cycles', tooltip: 'Total processor cycles executed' },
         { value: 'instructions', label: 'Instructions', tooltip: 'Instructions executed by the CPU' },
@@ -86,39 +101,28 @@ const ProfilingTopPanel = ({
         { value: 'branch-instructions', label: 'Branch Instructions', tooltip: 'Conditional jump instructions executed' },
         { value: 'branch-misses', label: 'Branch Misses', tooltip: 'Mispredicted branches - impacts pipeline efficiency' },
         { value: 'stalled-cycles-frontend', label: 'Stalled Cycles (Frontend)', tooltip: 'CPU cycles stalled waiting for instructions' },
-        { value: 'stalled-cycles-backend', label: 'Stalled Cycles (Backend)', tooltip: 'CPU cycles stalled during execution (CPU-dependent)' }
+        { value: 'stalled-cycles-backend', label: 'Stalled Cycles (Backend)', tooltip: 'CPU cycles stalled during execution (CPU-dependent)' },
     ];
 
-    // Profiler configuration definitions
     const profilerDefinitions = [
-        {
-            key: 'perf',
-            name: 'Perf Profiler',
-            description: 'C, C++, Go, Kernel',
-            options: [
-                { value: 'enabled_restricted', label: 'Enabled Restricted', tooltip: 'Profiles only top N containers/process', default: true },
-                { value: 'enabled_aggressive', label: 'Enabled Aggressive', tooltip: 'Profiles all processes' },
-                { value: 'disabled', label: 'Disabled' }
-            ]
-        },
         {
             key: 'pyperf',
             name: 'Pyperf',
             description: "Python's highly optimized eBPF. Exception - arm64 hosts",
             options: [
-                { value: 'enabled', label: 'Enabled', default: true },
-                { value: 'disabled', label: 'Disabled' }
-            ]
+                { value: 'enabled', label: 'Enabled' },
+                { value: 'disabled', label: 'Disabled' },
+            ],
         },
         {
             key: 'pyspy',
             name: 'Pyspy',
             description: 'Python',
             options: [
-                { value: 'enabled_fallback', label: 'Enabled as Fallback for Pyperf', default: true },
+                { value: 'enabled_fallback', label: 'Enabled as Fallback for Pyperf' },
                 { value: 'enabled', label: 'Enabled' },
-                { value: 'disabled', label: 'Disabled' }
-            ]
+                { value: 'disabled', label: 'Disabled' },
+            ],
         },
         {
             key: 'rbspy',
@@ -126,8 +130,8 @@ const ProfilingTopPanel = ({
             description: 'Ruby',
             options: [
                 { value: 'enabled', label: 'Enabled' },
-                { value: 'disabled', label: 'Disabled', default: true }
-            ]
+                { value: 'disabled', label: 'Disabled' },
+            ],
         },
         {
             key: 'phpspy',
@@ -135,8 +139,8 @@ const ProfilingTopPanel = ({
             description: 'PHP',
             options: [
                 { value: 'enabled', label: 'Enabled' },
-                { value: 'disabled', label: 'Disabled', default: true }
-            ]
+                { value: 'disabled', label: 'Disabled' },
+            ],
         },
         {
             key: 'dotnet_trace',
@@ -144,485 +148,373 @@ const ProfilingTopPanel = ({
             description: '.NET',
             options: [
                 { value: 'enabled', label: 'Enabled' },
-                { value: 'disabled', label: 'Disabled', default: true }
-            ]
+                { value: 'disabled', label: 'Disabled' },
+            ],
         },
         {
             key: 'nodejs_perf',
-            name: 'Perf',
+            name: 'Perl',
             description: 'NodeJS',
             options: [
-                { value: 'enabled', label: 'Enabled', default: true },
-                { value: 'disabled', label: 'Disabled' }
-            ]
-        }
+                { value: 'enabled', label: 'Enabled' },
+                { value: 'disabled', label: 'Disabled' },
+            ],
+        },
     ];
 
+    const profilerCardSx = {
+        border: '1px solid #e0e0e0',
+        borderRadius: 2,
+        p: 2,
+        backgroundColor: '#fff',
+    };
+
+    const clampInt = (raw, min, max) => {
+        const value = parseInt(raw, 10);
+        if (Number.isNaN(value)) return null;
+        return Math.min(Math.max(value, min), max);
+    };
+
     return (
-        <Flexbox column spacing={2}>
-            <Box
-                sx={{
-                    background: `linear-gradient(180deg,${COLORS.ALMOST_WHITE} 50%, ${COLORS.WHITE} 50%)`,
-                    px: 4,
-                    zIndex: 1,
-                }}>
-                <Flexbox
-                    spacing={4}
-                    justifyContent='space-between'
-                    alignItems='center'
-                    sx={{
-                        height: '45px',
-                        width: '100%',
-                        backgroundColor: 'white.main',
-                        boxShadow: '0px 8px 12px rgba(9, 30, 66, 0.15), 0px 0px 1px rgba(9, 30, 66, 0.31)',
-                        borderRadius: '26px',
-                        px: 5,
-                    }}>
-                    {/* Left side - Action Buttons */}
-                    <Flexbox alignItems='center' spacing={2} divider={<PanelDivider />}>
-                        <Button
-                            variant='contained'
-                            color='success'
-                            size='small'
-                            onClick={() => handleBulkAction('start')}
-                            disabled={selectionModel.length === 0}>
-                            Start ({selectionModel.length})
-                        </Button>
-                        <Button
-                            variant='contained'
-                            color='error'
-                            size='small'
-                            onClick={() => handleBulkAction('stop')}
-                            disabled={selectionModel.length === 0}>
-                            Stop ({selectionModel.length})
-                        </Button>
-                        <Button
-                            variant='outlined'
-                            color='primary'
-                            size='small'
-                            onClick={() => fetchProfilingStatus(filters)}
-                            disabled={loading}>
-                            Refresh
-                        </Button>
-                        
-                        {/* PerfSpect Hardware Metrics Checkbox */}
-                        <Tooltip title="Enable Intel PerfSpect hardware metrics collection (auto-installs on agents)">
+        <Box sx={{ px: 4, pb: 3, display: 'flex', flexDirection: 'column', gap: 3 }}>
+            {/* Basic Configuration */}
+            <Paper variant='outlined' sx={{ borderRadius: 2, p: 3 }}>
+                <Typography variant='subtitle1' sx={{ fontWeight: 600, mb: 3 }}>
+                    Basic Configuration
+                </Typography>
+                <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' }, gap: 4 }}>
+                    {/* Left column */}
+                    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+                        <Tooltip title='Enable Intel PerfSpect hardware metrics collection (auto-installs on agents)'>
                             <FormControlLabel
                                 control={
                                     <Checkbox
                                         checked={enablePerfSpect}
                                         onChange={(e) => onPerfSpectChange(e.target.checked)}
-                                        size="small"
-                                        color="primary"
+                                        size='small'
+                                        color='primary'
                                     />
                                 }
                                 label={
-                                    <Typography variant="body2" sx={{ fontSize: '0.875rem' }}>
+                                    <Typography variant='body2' sx={{ fontSize: '0.875rem' }}>
                                         PerfSpect HW Metrics
                                     </Typography>
                                 }
-                                sx={{ ml: 1 }}
+                                sx={{ m: 0 }}
                             />
                         </Tooltip>
-                        
-                        {/* Profiling Frequency Field */}
-                        <Tooltip title="Number of samples per second for profiling duration (Hz)">
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, pl: 5 }}>
-                                <Typography variant="body2" sx={{ fontSize: '0.875rem', whiteSpace: 'nowrap' }}>
-                                    Profiling Frequency:
-                                </Typography>
+
+                        <Box>
+                            <Label>Profiling Frequency (Hz)</Label>
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                                 <TextField
                                     value={profilingFrequency}
                                     onChange={(e) => {
-                                        const value = parseInt(e.target.value, 10);
-                                        if (!isNaN(value) && value > 0 && value <= 1000) {
-                                            onProfilingFrequencyChange(value);
-                                        }
+                                        const value = clampInt(e.target.value, 1, 1000);
+                                        if (value !== null) onProfilingFrequencyChange(value);
                                     }}
-                                    type="number"
-                                    size="small"
-                                    inputProps={{
-                                        min: 1,
-                                        max: 1000,
-                                        style: { textAlign: 'center' }
-                                    }}
-                                    sx={{
-                                        width: '70px',
-                                        '& .MuiOutlinedInput-root': {
-                                            height: '32px',
-                                            fontSize: '0.875rem'
-                                        }
-                                    }}
+                                    type='number'
+                                    size='small'
+                                    inputProps={{ min: 1, max: 1000 }}
+                                    sx={fieldSx}
                                 />
-                                <Typography variant="body2" sx={{ fontSize: '0.75rem', color: 'text.secondary' }}>
+                                <Typography variant='body2' sx={{ color: 'text.secondary' }}>
                                     Hz
                                 </Typography>
                             </Box>
-                        </Tooltip>
-                        
-                        {/* Max Processes Field */}
-                        <Tooltip title="Maximum number of processes to profile per runtime profiler (all profilers except perf and ebpf)">
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, pl: 5 }}>
-                                <Typography variant="body2" sx={{ fontSize: '0.875rem', whiteSpace: 'nowrap' }}>
-                                    Max Processes:
-                                </Typography>
+                            <Helper>Sampling rate (11, 49, 99, 199 Hz)</Helper>
+                        </Box>
+
+                        <Box>
+                            <Label>Max Processes</Label>
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                                 <TextField
                                     value={maxProcesses}
                                     onChange={(e) => {
-                                        const value = parseInt(e.target.value, 10);
-                                        if (!isNaN(value) && value >= 0 && value <= 1000) {
-                                            onMaxProcessesChange(value);
-                                        }
+                                        const value = clampInt(e.target.value, 0, 1000);
+                                        if (value !== null) onMaxProcessesChange(value);
                                     }}
-                                    type="number"
-                                    size="small"
-                                    inputProps={{
-                                        min: 0,
-                                        max: 1000,
-                                        style: { textAlign: 'center' }
-                                    }}
-                                    sx={{
-                                        width: '70px',
-                                        '& .MuiOutlinedInput-root': {
-                                            height: '32px',
-                                            fontSize: '0.875rem'
-                                        }
-                                    }}
+                                    type='number'
+                                    size='small'
+                                    inputProps={{ min: 0, max: 1000 }}
+                                    sx={fieldSx}
                                 />
-                                <Typography variant="body2" sx={{ fontSize: '0.75rem', color: 'text.secondary' }}>
-                                    procs
+                                <Typography variant='body2' sx={{ color: 'text.secondary' }}>
+                                    processes
                                 </Typography>
                             </Box>
-                        </Tooltip>
-                    </Flexbox>
-                    
-                    {/* Profiling Mode and Duration Section */}
-                    <Flexbox alignItems='center' spacing={2}>
-                        {/* Profiling Mode Radio Buttons */}
-                        <Tooltip title="Select profiling mode: Continuous for ongoing profiling (60s fixed), or Ad Hoc for one-time profiling with custom duration">
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-                                <Typography variant="body2" sx={{ fontSize: '0.875rem', whiteSpace: 'nowrap' }}>
-                                    Mode:
-                                </Typography>
-                                <RadioGroup
-                                    row
-                                    value={profilingMode}
-                                    onChange={(e) => onProfilingModeChange(e.target.value)}
-                                    sx={{ gap: 1, ml: 1 }}
-                                >
-                                    <FormControlLabel
-                                        value="continuous"
-                                        control={<Radio size="small" />}
-                                        label={
-                                            <Typography variant="body2" sx={{ fontSize: '0.875rem' }}>
-                                                Continuous
-                                            </Typography>
-                                        }
-                                    />
-                                    <FormControlLabel
-                                        value="adhoc"
-                                        control={<Radio size="small" />}
-                                        label={
-                                            <Typography variant="body2" sx={{ fontSize: '0.875rem' }}>
-                                                Ad Hoc
-                                            </Typography>
-                                        }
-                                    />
-                                </RadioGroup>
-                            </Box>
-                        </Tooltip>
-                        
-                        {/* Duration Field */}
-                        <Tooltip title={profilingMode === 'continuous' ? 'Duration is fixed at 60 seconds for Continuous mode' : 'Profiling duration in seconds (only editable in Ad Hoc mode)'}>
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                                <Typography variant="body2" sx={{ fontSize: '0.875rem', whiteSpace: 'nowrap' }}>
-                                    Duration:
-                                </Typography>
-                                <TextField
-                                    value={profilingMode === 'continuous' ? 60 : duration}
-                                    onChange={(e) => {
-                                        const value = parseInt(e.target.value, 10);
-                                        if (!isNaN(value) && value > 0 && value <= 3600) {
-                                            onDurationChange(value);
-                                        }
-                                    }}
-                                    type="number"
-                                    size="small"
-                                    disabled={profilingMode === 'continuous'}
-                                    inputProps={{
-                                        min: 1,
-                                        max: 3600,
-                                        style: { textAlign: 'center' }
-                                    }}
-                                    sx={{
-                                        width: '70px',
-                                        '& .MuiOutlinedInput-root': {
-                                            height: '32px',
-                                            fontSize: '0.875rem',
-                                            backgroundColor: profilingMode === 'continuous' ? '#f5f5f5' : 'white'
-                                        }
-                                    }}
-                                />
-                                <Typography variant="body2" sx={{ fontSize: '0.75rem', color: 'text.secondary' }}>
-                                    sec
-                                </Typography>
-                            </Box>
-                        </Tooltip>
-                    </Flexbox>
+                        </Box>
+                    </Box>
 
-                    {/* Right side - Info and Clear Filters */}
-                    <Flexbox spacing={3} alignItems='center' divider={<PanelDivider />}>
-                        {hasActiveFilters && (
-                            <Button variant='outlined' color='secondary' size='small' onClick={clearAllFilters}>
-                                Clear Filters
-                            </Button>
-                        )}
-                        <Typography variant='body2' color='text.secondary' sx={{ fontSize: '0.8rem' }}>
-                            {activeCount} {activeLabel} of {totalCount} {totalLabel}
-                        </Typography>
-                    </Flexbox>
-                </Flexbox>
-            </Box>
-            {/* Profiler Configuration Section */}
-            <Box sx={{ px: 5, width: '100%' }}>
-                <Accordion sx={{ boxShadow: 'none', border: '1px solid #e0e0e0' }}>
-                    <AccordionSummary
-                        expandIcon={<Typography sx={{ fontSize: '1.2rem' }}>▼</Typography>}
-                        sx={{ 
-                            backgroundColor: '#f5f5f5',
-                            '& .MuiAccordionSummary-content': {
-                                alignItems: 'center'
-                            }
-                        }}
-                    >
-                        <Typography variant="body2" sx={{ fontSize: '0.875rem', fontWeight: 500 }}>
-                            Click for Advanced Profiler Configuration
-                        </Typography>
-                    </AccordionSummary>
-                    <AccordionDetails sx={{ p: 3 }}>
-                        <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: 3 }}>
-                            {/* Render Perf Profiler first with Event Selector */}
-                            <Box sx={{ 
-                                    border: '1px solid #e0e0e0', 
-                                    borderRadius: 2, 
-                                    p: 2,
-                                    backgroundColor: '#fafafa'
-                                }}>
-                                    <Typography variant="body2" sx={{ fontSize: '0.875rem', fontWeight: 600, mb: 0.5 }}>
-                                    Perf Profiler
-                                    </Typography>
-                                    <Typography variant="body2" sx={{ fontSize: '0.75rem', color: 'text.secondary', mb: 2 }}>
-                                    C, C++, Go, Kernel
-                                    </Typography>
-                                
-                                {/* Mode Selection */}
-                                    <RadioGroup
-                                    value={profilerConfigs.perf?.mode || 'enabled_restricted'}
-                                    onChange={(e) => handlePerfProfilerConfigChange('mode', e.target.value)}
-                                >
-                                    <Tooltip 
-                                        title="Profiles only top N containers/process" 
-                                        placement="right"
-                                        arrow
-                                    >
-                                        <FormControlLabel
-                                            value="enabled_restricted"
-                                            control={<Radio size="small" />}
-                                            label={
-                                                <Typography variant="body2" sx={{ fontSize: '0.75rem' }}>
-                                                    Enabled Restricted
-                                                </Typography>
-                                            }
-                                            sx={{ mb: 0.5 }}
-                                        />
-                                    </Tooltip>
-                                    <Tooltip 
-                                        title="Profiles all processes" 
-                                        placement="right"
-                                        arrow
-                                    >
-                                        <FormControlLabel
-                                            value="enabled_aggressive"
-                                            control={<Radio size="small" />}
-                                            label={
-                                                <Typography variant="body2" sx={{ fontSize: '0.75rem' }}>
-                                                    Enabled Aggressive
-                                                </Typography>
-                                            }
-                                            sx={{ mb: 0.5 }}
-                                        />
-                                    </Tooltip>
+                    {/* Right column */}
+                    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+                        <Box>
+                            <Label>Mode</Label>
+                            <RadioGroup
+                                row
+                                value={profilingMode}
+                                onChange={(e) => onProfilingModeChange(e.target.value)}>
+                                <FormControlLabel
+                                    value='adhoc'
+                                    control={<Radio size='small' />}
+                                    label={<Typography variant='body2' sx={{ fontSize: '0.875rem' }}>Ad Hoc</Typography>}
+                                />
+                                <FormControlLabel
+                                    value='continuous'
+                                    control={<Radio size='small' />}
+                                    label={<Typography variant='body2' sx={{ fontSize: '0.875rem' }}>Continuous</Typography>}
+                                />
+                            </RadioGroup>
+                            <Helper>
+                                {isAdhoc
+                                    ? 'Single profiling session with specified duration'
+                                    : 'Ongoing profiling (duration fixed at 60 seconds)'}
+                            </Helper>
+                        </Box>
+
+                        <Box>
+                            <Label>Duration</Label>
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                <TextField
+                                    value={isAdhoc ? duration : 60}
+                                    onChange={(e) => {
+                                        const value = clampInt(e.target.value, 1, 3600);
+                                        if (value !== null) onDurationChange(value);
+                                    }}
+                                    type='number'
+                                    size='small'
+                                    disabled={!isAdhoc}
+                                    inputProps={{ min: 1, max: 3600 }}
+                                    sx={{
+                                        ...fieldSx,
+                                        '& .MuiOutlinedInput-root': {
+                                            ...fieldSx['& .MuiOutlinedInput-root'],
+                                            backgroundColor: isAdhoc ? 'white' : '#f5f5f5',
+                                        },
+                                    }}
+                                />
+                                <Typography variant='body2' sx={{ color: 'text.secondary' }}>
+                                    seconds
+                                </Typography>
+                            </Box>
+                        </Box>
+                    </Box>
+                </Box>
+            </Paper>
+
+            {/* Advanced Profiler Configuration */}
+            <Accordion variant='outlined' sx={{ borderRadius: 2, '&:before': { display: 'none' } }}>
+                <AccordionSummary
+                    expandIcon={<Icon name={ICONS_NAMES.ChevronDown} size={20} color='#6b7280' />}
+                    sx={{ '& .MuiAccordionSummary-content': { alignItems: 'center', gap: 1 } }}>
+                    <Typography variant='subtitle1' sx={{ fontWeight: 600 }}>
+                        Advanced Profiler Configuration
+                    </Typography>
+                    <Tooltip title='Configure per-language profilers used during the profiling session'>
+                        <Box
+                            sx={{
+                                display: 'inline-flex',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                                width: 16,
+                                height: 16,
+                                borderRadius: '50%',
+                                border: '1px solid #9ca3af',
+                                color: '#6b7280',
+                                fontSize: '0.7rem',
+                            }}>
+                            i
+                        </Box>
+                    </Tooltip>
+                </AccordionSummary>
+                <AccordionDetails sx={{ p: 3, pt: 0 }}>
+                    <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: 3 }}>
+                        {/* Perf Profiler */}
+                        <Box sx={profilerCardSx}>
+                            <Typography variant='body2' sx={{ fontSize: '0.875rem', fontWeight: 600, mb: 0.5 }}>
+                                Perf Profiler
+                            </Typography>
+                            <Typography variant='body2' sx={{ fontSize: '0.75rem', color: 'text.secondary', mb: 2 }}>
+                                C, C++, Go, Kernel
+                            </Typography>
+                            <RadioGroup
+                                value={profilerConfigs.perf?.mode || 'enabled_restricted'}
+                                onChange={(e) => handlePerfProfilerConfigChange('mode', e.target.value)}>
+                                <Tooltip title='Profiles only top N containers/process' placement='right' arrow>
                                     <FormControlLabel
-                                        value="disabled"
-                                        control={<Radio size="small" />}
-                                        label={
-                                            <Typography variant="body2" sx={{ fontSize: '0.75rem' }}>
-                                                Disabled
-                                            </Typography>
-                                        }
+                                        value='enabled_restricted'
+                                        control={<Radio size='small' />}
+                                        label={<Typography variant='body2' sx={{ fontSize: '0.75rem' }}>Enabled Restricted</Typography>}
                                         sx={{ mb: 0.5 }}
                                     />
-                                </RadioGroup>
-                                
-                                {/* Event Selection - Only show when perf is enabled */}
-                                {profilerConfigs.perf?.mode !== 'disabled' && (
-                                    <Box sx={{ ml: 3, mt: 2 }}>
-                                        <Typography variant="body2" sx={{ fontSize: '0.75rem', fontWeight: 500, mb: 1 }}>
-                                            Event Types (select one or more):
-                                        </Typography>
-                                        <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-                                            {perfEvents.map(event => (
-                                                <Tooltip 
-                                                    key={event.value}
-                                                    title={event.tooltip} 
-                                                    placement="right"
-                                                    arrow
-                                                >
-                                                    <FormControlLabel
-                                                        control={
-                                                            <Checkbox
-                                                                checked={profilerConfigs.perf?.events?.includes(event.value) || false}
-                                                                onChange={(e) => handlePerfEventToggle(event.value, e.target.checked)}
-                                                                size="small"
-                                                            />
-                                                        }
-                                                        label={
-                                                            <Typography variant="body2" sx={{ fontSize: '0.75rem' }}>
-                                                                {event.label}
-                                                            </Typography>
-                                                        }
-                                                        sx={{ mb: 0.5 }}
-                                                    />
-                                                </Tooltip>
-                                            ))}
-                                        </Box>
-                                    </Box>
-                                )}
-                                </Box>
-                            
-                            {/* Custom Async Profiler Configuration - Right after Perf */}
-                            <Box sx={{ 
-                                border: '1px solid #e0e0e0', 
-                                borderRadius: 2, 
-                                p: 2,
-                                backgroundColor: '#fafafa'
-                            }}>
-                                <Typography variant="body2" sx={{ fontSize: '0.875rem', fontWeight: 600, mb: 0.5 }}>
-                                    Async Profiler
-                                </Typography>
-                                <Typography variant="body2" sx={{ fontSize: '0.75rem', color: 'text.secondary', mb: 2 }}>
-                                    Java
-                                </Typography>
-                                
-                                {/* Enable/Disable Toggle */}
+                                </Tooltip>
+                                <Tooltip title='Profiles all processes' placement='right' arrow>
+                                    <FormControlLabel
+                                        value='enabled_aggressive'
+                                        control={<Radio size='small' />}
+                                        label={<Typography variant='body2' sx={{ fontSize: '0.75rem' }}>Enabled Aggressive</Typography>}
+                                        sx={{ mb: 0.5 }}
+                                    />
+                                </Tooltip>
                                 <FormControlLabel
-                                    control={
-                                        <Checkbox
-                                            checked={profilerConfigs.async_profiler?.enabled || false}
-                                            onChange={(e) => handleAsyncProfilerConfigChange('enabled', e.target.checked)}
-                                            size="small"
-                                        />
-                                    }
-                                    label={
-                                        <Typography variant="body2" sx={{ fontSize: '0.75rem' }}>
-                                            Enabled
-                                        </Typography>
-                                    }
-                                    sx={{ mb: 1 }}
+                                    value='disabled'
+                                    control={<Radio size='small' />}
+                                    label={<Typography variant='body2' sx={{ fontSize: '0.75rem' }}>Disabled</Typography>}
+                                    sx={{ mb: 0.5 }}
                                 />
-                                
-                                {/* Time Mode Selection */}
-                                {profilerConfigs.async_profiler?.enabled && (
-                                    <Box sx={{ ml: 3 }}>
-                                        <Typography variant="body2" sx={{ fontSize: '0.75rem', fontWeight: 500, mb: 1 }}>
-                                            Time Mode:
-                                        </Typography>
-                                        <RadioGroup
-                                            value={profilerConfigs.async_profiler?.time || 'cpu'}
-                                            onChange={(e) => handleAsyncProfilerConfigChange('time', e.target.value)}
-                                        >
-                                            <Tooltip 
-                                                title="CPU time profiling - only when thread is running" 
-                                                placement="right"
-                                                arrow
-                                            >
-                                                <FormControlLabel
-                                                    value="cpu"
-                                                    control={<Radio size="small" />}
-                                                    label={
-                                                        <Typography variant="body2" sx={{ fontSize: '0.75rem' }}>
-                                                            CPU Time
-                                                        </Typography>
-                                                    }
-                                                    sx={{ mb: 0.5 }}
-                                                />
-                                            </Tooltip>
-                                            <Tooltip 
-                                                title="Wall clock time profiling - includes waiting/blocking time" 
-                                                placement="right"
-                                                arrow
-                                            >
-                                                <FormControlLabel
-                                                    value="wall"
-                                                    control={<Radio size="small" />}
-                                                    label={
-                                                        <Typography variant="body2" sx={{ fontSize: '0.75rem' }}>
-                                                            Wall Time
-                                                        </Typography>
-                                                    }
-                                                    sx={{ mb: 0.5 }}
-                                                />
-                                            </Tooltip>
-                                        </RadioGroup>
-                                    </Box>
-                                )}
-                            </Box>
-                            
-                            {/* Render remaining profilers (excluding perf) */}
-                            {profilerDefinitions.filter(p => p.key !== 'perf').map((profiler) => (
-                                <Box key={profiler.key} sx={{ 
-                                    border: '1px solid #e0e0e0', 
-                                    borderRadius: 2, 
-                                    p: 2,
-                                    backgroundColor: '#fafafa'
-                                }}>
-                                    <Typography variant="body2" sx={{ fontSize: '0.875rem', fontWeight: 600, mb: 0.5 }}>
-                                        {profiler.name}
+                            </RadioGroup>
+
+                            {profilerConfigs.perf?.mode !== 'disabled' && (
+                                <Box sx={{ ml: 3, mt: 2 }}>
+                                    <Typography variant='body2' sx={{ fontSize: '0.75rem', fontWeight: 500, mb: 1 }}>
+                                        Event Types (select one or more):
                                     </Typography>
-                                    <Typography variant="body2" sx={{ fontSize: '0.75rem', color: 'text.secondary', mb: 2 }}>
-                                        {profiler.description}
-                                    </Typography>
-                                    <RadioGroup
-                                        value={profilerConfigs[profiler.key]}
-                                        onChange={(e) => handleProfilerConfigChange(profiler.key, e.target.value)}
-                                    >
-                                        {profiler.options.map((option) => (
-                                            <Tooltip 
-                                                key={option.value} 
-                                                title={option.tooltip || ''} 
-                                                placement="right"
-                                                arrow
-                                            >
+                                    <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                                        {perfEvents.map((event) => (
+                                            <Tooltip key={event.value} title={event.tooltip} placement='right' arrow>
                                                 <FormControlLabel
-                                                    value={option.value}
-                                                    control={<Radio size="small" />}
-                                                    label={
-                                                        <Typography variant="body2" sx={{ fontSize: '0.75rem' }}>
-                                                            {option.label}
-                                                        </Typography>
+                                                    control={
+                                                        <Checkbox
+                                                            checked={profilerConfigs.perf?.events?.includes(event.value) || false}
+                                                            onChange={(e) => handlePerfEventToggle(event.value, e.target.checked)}
+                                                            size='small'
+                                                        />
                                                     }
+                                                    label={<Typography variant='body2' sx={{ fontSize: '0.75rem' }}>{event.label}</Typography>}
                                                     sx={{ mb: 0.5 }}
                                                 />
                                             </Tooltip>
                                         ))}
+                                    </Box>
+                                </Box>
+                            )}
+                        </Box>
+
+                        {/* Async Profiler */}
+                        <Box sx={profilerCardSx}>
+                            <Typography variant='body2' sx={{ fontSize: '0.875rem', fontWeight: 600, mb: 0.5 }}>
+                                Async Profiler
+                            </Typography>
+                            <Typography variant='body2' sx={{ fontSize: '0.75rem', color: 'text.secondary', mb: 2 }}>
+                                Java
+                            </Typography>
+                            <FormControlLabel
+                                control={
+                                    <Checkbox
+                                        checked={profilerConfigs.async_profiler?.enabled || false}
+                                        onChange={(e) => handleAsyncProfilerConfigChange('enabled', e.target.checked)}
+                                        size='small'
+                                    />
+                                }
+                                label={<Typography variant='body2' sx={{ fontSize: '0.75rem' }}>Enabled</Typography>}
+                                sx={{ mb: 1 }}
+                            />
+                            {profilerConfigs.async_profiler?.enabled && (
+                                <Box sx={{ ml: 3 }}>
+                                    <Typography variant='body2' sx={{ fontSize: '0.75rem', fontWeight: 500, mb: 1 }}>
+                                        Time Mode:
+                                    </Typography>
+                                    <RadioGroup
+                                        value={profilerConfigs.async_profiler?.time || 'cpu'}
+                                        onChange={(e) => handleAsyncProfilerConfigChange('time', e.target.value)}>
+                                        <Tooltip title='CPU time profiling - only when thread is running' placement='right' arrow>
+                                            <FormControlLabel
+                                                value='cpu'
+                                                control={<Radio size='small' />}
+                                                label={<Typography variant='body2' sx={{ fontSize: '0.75rem' }}>CPU Time</Typography>}
+                                                sx={{ mb: 0.5 }}
+                                            />
+                                        </Tooltip>
+                                        <Tooltip title='Wall clock time profiling - includes waiting/blocking time' placement='right' arrow>
+                                            <FormControlLabel
+                                                value='wall'
+                                                control={<Radio size='small' />}
+                                                label={<Typography variant='body2' sx={{ fontSize: '0.75rem' }}>Wall Time</Typography>}
+                                                sx={{ mb: 0.5 }}
+                                            />
+                                        </Tooltip>
                                     </RadioGroup>
                                 </Box>
-                            ))}
+                            )}
                         </Box>
-                    </AccordionDetails>
-                </Accordion>
+
+                        {/* Remaining language profilers */}
+                        {profilerDefinitions.map((profiler) => (
+                            <Box key={profiler.key} sx={profilerCardSx}>
+                                <Typography variant='body2' sx={{ fontSize: '0.875rem', fontWeight: 600, mb: 0.5 }}>
+                                    {profiler.name}
+                                </Typography>
+                                <Typography variant='body2' sx={{ fontSize: '0.75rem', color: 'text.secondary', mb: 2 }}>
+                                    {profiler.description}
+                                </Typography>
+                                <RadioGroup
+                                    value={profilerConfigs[profiler.key]}
+                                    onChange={(e) => handleProfilerConfigChange(profiler.key, e.target.value)}>
+                                    {profiler.options.map((option) => (
+                                        <Tooltip key={option.value} title={option.tooltip || ''} placement='right' arrow>
+                                            <FormControlLabel
+                                                value={option.value}
+                                                control={<Radio size='small' />}
+                                                label={<Typography variant='body2' sx={{ fontSize: '0.75rem' }}>{option.label}</Typography>}
+                                                sx={{ mb: 0.5 }}
+                                            />
+                                        </Tooltip>
+                                    ))}
+                                </RadioGroup>
+                            </Box>
+                        ))}
+                    </Box>
+                </AccordionDetails>
+            </Accordion>
+
+            {/* Action bar */}
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
+                <Button
+                    variant='contained'
+                    size='medium'
+                    onClick={() => handleBulkAction('start')}
+                    disabled={selectedCount === 0}
+                    startIcon={<Box component='span' sx={{ fontSize: '0.7rem' }}>▶</Box>}
+                    sx={{
+                        backgroundColor: ACTION_COLORS.start.bg,
+                        '&:hover': { backgroundColor: ACTION_COLORS.start.hover },
+                    }}>
+                    {`Start Profiling${selectedCount ? ` (${selectedCount})` : ''}`}
+                </Button>
+                <Button
+                    variant='contained'
+                    size='medium'
+                    onClick={() => handleBulkAction('stop')}
+                    disabled={selectedCount === 0}
+                    startIcon={<Box component='span' sx={{ fontSize: '0.7rem' }}>■</Box>}
+                    sx={{
+                        backgroundColor: ACTION_COLORS.stop.bg,
+                        '&:hover': { backgroundColor: ACTION_COLORS.stop.hover },
+                    }}>
+                    {`Stop Profiling${selectedCount ? ` (${selectedCount})` : ''}`}
+                </Button>
+                <Button
+                    variant='outlined'
+                    color='inherit'
+                    size='medium'
+                    onClick={() => fetchProfilingStatus(filters)}
+                    disabled={loading}
+                    startIcon={<Icon name={ICONS_NAMES.Refresh} size={18} color='#6b7280' />}>
+                    Refresh
+                </Button>
+                <Box sx={{ flexGrow: 1 }} />
+                <Button
+                    variant='contained'
+                    size='medium'
+                    onClick={onSaveConfiguration}
+                    sx={{
+                        backgroundColor: ACTION_COLORS.save.bg,
+                        '&:hover': { backgroundColor: ACTION_COLORS.save.hover },
+                    }}>
+                    Save Configuration
+                </Button>
             </Box>
-        </Flexbox>
+        </Box>
     );
 };
 

--- a/src/gprofiler/frontend/src/components/console/profilingRequestBuilder.mjs
+++ b/src/gprofiler/frontend/src/components/console/profilingRequestBuilder.mjs
@@ -1,0 +1,142 @@
+/*
+ * Pure (React-free) helpers that translate selected inventory rows into the
+ * payload accepted by POST /api/metrics/profile_request[/bulk].
+ *
+ * This module is intentionally dependency-free so the request-shaping "spec"
+ * can be exercised by fast unit/acceptance tests (see
+ * profilingRequestBuilder.test.mjs) without spinning up React or a browser.
+ *
+ * Contract (kept in sync with the backend ProfilingRequest validator):
+ *   - stop_level is "host" for the coarse scopes (service, host) and "process"
+ *     for the finer scopes; it is only set for stop requests.
+ *   - A host-/service-level stop must NOT carry any PID (neither in
+ *     target_hosts nor in target_entities), otherwise the backend rejects it.
+ *   - Process-level identifiers (pid, process_name) are therefore only attached
+ *     to target entities when the active scope is "process".
+ */
+
+// Scopes that resolve to whole-host targets (no per-process PIDs).
+export const HOST_LEVEL_SCOPES = ['service', 'host'];
+
+const CONTINUOUS_DURATION_SECONDS = 60;
+
+/**
+ * Build a single target entity descriptor for a selected row.
+ *
+ * Process-level identifiers (pid, process_name) are only included for the
+ * "process" scope. Attaching them to coarser scopes is unnecessary for target
+ * resolution and, for stop requests, trips the backend validation that forbids
+ * PIDs when stop_level is "host".
+ *
+ * @param {object} row - Normalized inventory row.
+ * @param {string} scope - Active scope (service|namespace|host|pod|container|process).
+ * @returns {object} Target entity payload.
+ */
+export const buildTargetEntity = (row, scope) => {
+    const entity = {
+        id: row.id,
+        service_name: row.service,
+        namespace: row.namespace || undefined,
+        hostname: row.host || undefined,
+        ip_address: row.ip || undefined,
+        pod_name: row.podName || undefined,
+        container_name: row.containerName || undefined,
+        workload_name: row.workloadName || undefined,
+        workload_kind: row.workloadKind || undefined,
+    };
+
+    if (scope === 'process') {
+        // Use a null check (not truthiness) so a legitimate PID of 0 is preserved.
+        entity.pid = row.pid == null ? undefined : row.pid;
+        entity.process_name = row.processName || undefined;
+    }
+
+    return entity;
+};
+
+/**
+ * Resolve the stop_level for a request given the action and scope.
+ * @returns {string|undefined} "host" | "process" for stops, undefined otherwise.
+ */
+export const resolveStopLevel = (action, scope) => {
+    if (action !== 'stop') {
+        return undefined;
+    }
+    return HOST_LEVEL_SCOPES.includes(scope) ? 'host' : 'process';
+};
+
+/**
+ * Group selected rows by their service name (preserving selection order).
+ * @param {Array<object>} selectedRows
+ * @returns {Record<string, Array<object>>}
+ */
+export const groupRowsByService = (selectedRows) =>
+    selectedRows.reduce((groups, row) => {
+        if (!groups[row.service]) {
+            groups[row.service] = [];
+        }
+        groups[row.service].push(row);
+        return groups;
+    }, {});
+
+/**
+ * Build the per-service profiling requests for a bulk start/stop action.
+ *
+ * @param {'start'|'stop'} action
+ * @param {Array<object>} selectedRows - Normalized inventory rows.
+ * @param {object} config
+ * @param {string} config.scope - Active scope.
+ * @param {'continuous'|'adhoc'|string} config.profilingMode
+ * @param {number} config.duration
+ * @param {number} config.profilingFrequency
+ * @param {boolean} config.enablePerfSpect
+ * @param {object} config.profilerConfigs
+ * @param {number} config.maxProcesses
+ * @returns {{grouped: Record<string, Array<object>>, requests: Array<object>}}
+ */
+export const buildProfilingRequests = (action, selectedRows, config) => {
+    const {
+        scope,
+        profilingMode,
+        duration,
+        profilingFrequency,
+        enablePerfSpect,
+        profilerConfigs,
+        maxProcesses,
+    } = config;
+
+    const grouped = groupRowsByService(selectedRows);
+    const isContinuous = profilingMode === 'continuous';
+    const stopLevel = resolveStopLevel(action, scope);
+
+    const requests = Object.entries(grouped).map(([serviceName, serviceRows]) => {
+        const targetHosts =
+            scope === 'host'
+                ? serviceRows.reduce((hostMap, row) => {
+                      // null => whole-host target (no PIDs) per the backend contract.
+                      hostMap[row.host] = null;
+                      return hostMap;
+                  }, {})
+                : undefined;
+
+        return {
+            service_name: serviceName,
+            request_type: action,
+            continuous: isContinuous,
+            duration: isContinuous ? CONTINUOUS_DURATION_SECONDS : duration,
+            frequency: profilingFrequency,
+            profiling_mode: 'cpu',
+            target_scope: scope,
+            target_hosts: targetHosts,
+            target_entities: serviceRows.map((row) => buildTargetEntity(row, scope)),
+            stop_level: stopLevel,
+            additional_args: {
+                enable_perfspect: enablePerfSpect,
+                profiler_configs: profilerConfigs,
+                max_processes: maxProcesses,
+            },
+        };
+    });
+
+    return { grouped, requests };
+};

--- a/src/gprofiler/frontend/src/components/console/profilingRequestBuilder.test.mjs
+++ b/src/gprofiler/frontend/src/components/console/profilingRequestBuilder.test.mjs
@@ -1,0 +1,296 @@
+/*
+ * Acceptance / spec tests for the profiling request builder.
+ *
+ * These encode the executable specification for how the Profiling Status page
+ * turns selected inventory rows into POST /api/metrics/profile_request payloads.
+ * They run with Node's built-in test runner (no extra dependencies):
+ *
+ *     node --test src/gprofiler/frontend/src/components/console/profilingRequestBuilder.test.mjs
+ *
+ * The central invariant (which the original host/service stop bug violated):
+ *   A host- or service-level STOP must never carry a PID, or the backend
+ *   ProfilingRequest validator rejects it with
+ *   'No PIDs should be provided when request_type is "stop" and stop_level is "host"'.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+    HOST_LEVEL_SCOPES,
+    buildProfilingRequests,
+    buildTargetEntity,
+    groupRowsByService,
+    resolveStopLevel,
+} from './profilingRequestBuilder.mjs';
+
+const baseConfig = {
+    scope: 'host',
+    profilingMode: 'adhoc',
+    duration: 120,
+    profilingFrequency: 11,
+    enablePerfSpect: false,
+    profilerConfigs: {},
+    maxProcesses: 10,
+};
+
+const makeRow = (overrides = {}) => ({
+    id: 'row-1',
+    service: 'svc-a',
+    namespace: 'ns-a',
+    host: 'host-a',
+    ip: '10.0.0.1',
+    podName: 'pod-a',
+    containerName: 'cont-a',
+    workloadName: 'wl-a',
+    workloadKind: 'Deployment',
+    processName: 'python',
+    pid: 4242,
+    ...overrides,
+});
+
+// Every target entity produced for a request, flattened.
+const allEntities = (requests) => requests.flatMap((r) => r.target_entities);
+// True when any produced entity carries a PID (what the backend forbids for host stops).
+const anyEntityHasPid = (requests) => allEntities(requests).some((e) => e.pid !== undefined);
+
+describe('buildTargetEntity', () => {
+    it('omits process-level identifiers (pid/process_name) for coarse scopes', () => {
+        for (const scope of ['service', 'host', 'namespace', 'workload', 'pod', 'container']) {
+            const entity = buildTargetEntity(makeRow(), scope);
+            assert.equal(entity.pid, undefined, `pid must be undefined for scope=${scope}`);
+            assert.equal(
+                entity.process_name,
+                undefined,
+                `process_name must be undefined for scope=${scope}`
+            );
+        }
+    });
+
+    it('includes pid and process_name for the process scope', () => {
+        const entity = buildTargetEntity(makeRow({ pid: 4242, processName: 'python' }), 'process');
+        assert.equal(entity.pid, 4242);
+        assert.equal(entity.process_name, 'python');
+    });
+
+    it('preserves a legitimate PID of 0 (not dropped as falsy)', () => {
+        const entity = buildTargetEntity(makeRow({ pid: 0 }), 'process');
+        assert.equal(entity.pid, 0);
+    });
+
+    it('treats a missing PID as undefined for the process scope', () => {
+        const entity = buildTargetEntity(makeRow({ pid: null }), 'process');
+        assert.equal(entity.pid, undefined);
+    });
+
+    it('always carries the identifying fields needed for host-scope resolution', () => {
+        const entity = buildTargetEntity(makeRow(), 'host');
+        assert.equal(entity.service_name, 'svc-a');
+        assert.equal(entity.hostname, 'host-a');
+    });
+});
+
+describe('resolveStopLevel', () => {
+    it('is undefined for start requests regardless of scope', () => {
+        for (const scope of ['service', 'host', 'process']) {
+            assert.equal(resolveStopLevel('start', scope), undefined);
+        }
+    });
+
+    it('is "host" for coarse (service/host) stop scopes', () => {
+        for (const scope of HOST_LEVEL_SCOPES) {
+            assert.equal(resolveStopLevel('stop', scope), 'host');
+        }
+    });
+
+    it('is "process" for finer stop scopes', () => {
+        for (const scope of ['namespace', 'workload', 'pod', 'container', 'process']) {
+            assert.equal(resolveStopLevel('stop', scope), 'process');
+        }
+    });
+});
+
+describe('groupRowsByService', () => {
+    it('groups rows by service preserving order', () => {
+        const grouped = groupRowsByService([
+            makeRow({ id: '1', service: 'svc-a' }),
+            makeRow({ id: '2', service: 'svc-b' }),
+            makeRow({ id: '3', service: 'svc-a' }),
+        ]);
+        assert.deepEqual(Object.keys(grouped), ['svc-a', 'svc-b']);
+        assert.equal(grouped['svc-a'].length, 2);
+        assert.equal(grouped['svc-b'].length, 1);
+    });
+});
+
+describe('buildProfilingRequests — host-level stop (the regression)', () => {
+    it('produces a host-level stop with no PIDs anywhere', () => {
+        const { requests } = buildProfilingRequests('stop', [makeRow()], {
+            ...baseConfig,
+            scope: 'host',
+        });
+
+        assert.equal(requests.length, 1);
+        const [req] = requests;
+        assert.equal(req.request_type, 'stop');
+        assert.equal(req.stop_level, 'host');
+        // target_hosts maps host -> null (whole-host target, no PIDs).
+        assert.deepEqual(req.target_hosts, { 'host-a': null });
+        // No target entity may carry a PID.
+        assert.equal(anyEntityHasPid(requests), false);
+    });
+
+    it('produces a service-level stop with no PIDs and no target_hosts map', () => {
+        const { requests } = buildProfilingRequests('stop', [makeRow()], {
+            ...baseConfig,
+            scope: 'service',
+        });
+
+        const [req] = requests;
+        assert.equal(req.stop_level, 'host');
+        assert.equal(req.target_scope, 'service');
+        assert.equal(req.target_hosts, undefined);
+        assert.equal(anyEntityHasPid(requests), false);
+    });
+});
+
+describe('buildProfilingRequests — process-level stop', () => {
+    it('is a process-level stop that includes the PID', () => {
+        const { requests } = buildProfilingRequests('stop', [makeRow({ pid: 4242 })], {
+            ...baseConfig,
+            scope: 'process',
+        });
+
+        const [req] = requests;
+        assert.equal(req.stop_level, 'process');
+        assert.equal(req.target_hosts, undefined);
+        assert.equal(req.target_entities[0].pid, 4242);
+        assert.equal(anyEntityHasPid(requests), true);
+    });
+});
+
+describe('buildProfilingRequests — start requests', () => {
+    it('never sets stop_level for a start', () => {
+        for (const scope of ['service', 'host', 'process']) {
+            const { requests } = buildProfilingRequests('start', [makeRow()], {
+                ...baseConfig,
+                scope,
+            });
+            assert.equal(requests[0].stop_level, undefined);
+        }
+    });
+
+    it('forces continuous mode to a 60s duration', () => {
+        const { requests } = buildProfilingRequests('start', [makeRow()], {
+            ...baseConfig,
+            profilingMode: 'continuous',
+            duration: 999,
+        });
+        assert.equal(requests[0].continuous, true);
+        assert.equal(requests[0].duration, 60);
+    });
+
+    it('uses the configured duration for ad-hoc mode', () => {
+        const { requests } = buildProfilingRequests('start', [makeRow()], {
+            ...baseConfig,
+            profilingMode: 'adhoc',
+            duration: 120,
+        });
+        assert.equal(requests[0].continuous, false);
+        assert.equal(requests[0].duration, 120);
+    });
+});
+
+describe('buildProfilingRequests — multi-service', () => {
+    it('emits one request per service', () => {
+        const { requests } = buildProfilingRequests(
+            'stop',
+            [
+                makeRow({ id: '1', service: 'svc-a', host: 'h1' }),
+                makeRow({ id: '2', service: 'svc-b', host: 'h2' }),
+            ],
+            { ...baseConfig, scope: 'host' }
+        );
+
+        assert.equal(requests.length, 2);
+        assert.deepEqual(
+            requests.map((r) => r.service_name).sort(),
+            ['svc-a', 'svc-b']
+        );
+        assert.equal(anyEntityHasPid(requests), false);
+    });
+});
+
+/*
+ * The client half of the WORKLOAD_LEVEL_PROFILING_SPEC.md resolution contract.
+ * The backend does the actual host/PID resolution, but the request the UI emits
+ * must carry exactly the selectors each scope needs — and nothing that would be
+ * rejected. These map to AT-S5 (host start), AT-S6 (service fan-out), and AT-S7
+ * (workload scopes resolve to PIDs).
+ */
+describe('buildProfilingRequests — scope matrix (start)', () => {
+    // AT-S5: a host-scope start targets the concrete host via target_hosts.
+    it('host scope emits a target_hosts map and no PIDs', () => {
+        const { requests } = buildProfilingRequests('start', [makeRow({ host: 'host-a' })], {
+            ...baseConfig,
+            scope: 'host',
+        });
+        assert.deepEqual(requests[0].target_hosts, { 'host-a': null });
+        assert.equal(anyEntityHasPid(requests), false);
+    });
+
+    // AT-S6: a service-scope start carries no target_hosts (backend fans out to
+    // every current host of the service) but still names the service.
+    it('service scope carries the service selector and no target_hosts', () => {
+        const { requests } = buildProfilingRequests(
+            'start',
+            [makeRow({ service: 'svc-a', host: 'h1' }), makeRow({ id: '2', service: 'svc-a', host: 'h2' })],
+            { ...baseConfig, scope: 'service' }
+        );
+        assert.equal(requests.length, 1);
+        assert.equal(requests[0].service_name, 'svc-a');
+        assert.equal(requests[0].target_hosts, undefined);
+        assert.equal(requests[0].target_scope, 'service');
+        assert.equal(anyEntityHasPid(requests), false);
+    });
+
+    // AT-S7: namespace/workload/pod/container select via entity metadata (no PID
+    // on the client — the backend resolves these to PIDs), while `process`
+    // carries the concrete PID.
+    it('sub-host scopes attach the right selectors; only process carries a PID', () => {
+        const cases = {
+            namespace: (e) => assert.equal(e.namespace, 'ns-a'),
+            workload: (e) => assert.equal(e.workload_name, 'wl-a'),
+            pod: (e) => assert.equal(e.pod_name, 'pod-a'),
+            container: (e) => assert.equal(e.container_name, 'cont-a'),
+        };
+        for (const [scope, assertSelector] of Object.entries(cases)) {
+            const { requests } = buildProfilingRequests('start', [makeRow()], { ...baseConfig, scope });
+            const [entity] = requests[0].target_entities;
+            assertSelector(entity);
+            assert.equal(entity.pid, undefined, `pid must be undefined for scope=${scope}`);
+        }
+
+        const { requests: procReqs } = buildProfilingRequests('start', [makeRow({ pid: 4242 })], {
+            ...baseConfig,
+            scope: 'process',
+        });
+        assert.equal(procReqs[0].target_entities[0].pid, 4242);
+    });
+
+    it('threads perf/perfspect config through additional_args unchanged', () => {
+        const profilerConfigs = { perf: { mode: 'enabled_restricted', events: ['cycles'] } };
+        const { requests } = buildProfilingRequests('start', [makeRow()], {
+            ...baseConfig,
+            scope: 'service',
+            enablePerfSpect: true,
+            profilerConfigs,
+            maxProcesses: 25,
+        });
+        assert.deepEqual(requests[0].additional_args, {
+            enable_perfspect: true,
+            profiler_configs: profilerConfigs,
+            max_processes: 25,
+        });
+    });
+});

--- a/src/tests/spec/backend/test_pmu_and_capacity_spec.py
+++ b/src/tests/spec/backend/test_pmu_and_capacity_spec.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""
+Fast acceptance tests for pre-dispatch profiling guardrails:
+
+* PMU event validation  -> WORKLOAD_LEVEL_PROFILING_SPEC.md AT-S9
+* Profiling capacity     -> capacity guardrails referenced by AT-S6 fan-out
+
+These exercise the pure decision logic in
+``backend.utils.dynamic_profiling_utils`` with an in-memory fake DBManager, so
+they run in-process with no database or HTTP server (fast).
+
+Run:
+    cd src && python -m pytest tests/spec/backend/test_pmu_and_capacity_spec.py -v
+"""
+
+import pytest
+
+pytest.importorskip("pydantic", reason="pydantic is required for these spec tests")
+pytest.importorskip("humps", reason="pyhumps is required for these spec tests")
+
+try:
+    from backend.models.metrics_models import BulkProfilingRequest, ProfilingRequest
+    from backend.utils.dynamic_profiling_utils import validate_pmu_events, validate_profiling_capacity
+except Exception as exc:  # pragma: no cover - environment guard
+    pytest.skip(f"backend modules not importable: {exc}", allow_module_level=True)
+
+
+class FakeDBManager:
+    """Minimal stand-in for DBManager covering only the methods the guardrails call."""
+
+    def __init__(
+        self,
+        *,
+        active_hosts=0,
+        profiling_total=0,
+        profiling_inside=0,
+        profiling_outside=0,
+        unsupported_events=None,
+    ):
+        self._active_hosts = active_hosts
+        self._profiling_total = profiling_total
+        self._profiling_inside = profiling_inside
+        self._profiling_outside = profiling_outside
+        self._unsupported_events = set(unsupported_events or [])
+
+    # -- capacity --
+    def get_active_hosts_count(self, service_name=None):
+        return self._active_hosts
+
+    def get_actively_profiling_hosts_count(
+        self, service_name=None, host_inclusion_list=None, host_exclusion_list=None
+    ):
+        if host_inclusion_list is not None:
+            return self._profiling_inside
+        if host_exclusion_list is not None:
+            return self._profiling_outside
+        return self._profiling_total
+
+    # -- PMU --
+    def validate_perf_events_support(self, service_name, requested_events, target_hostnames=None):
+        bad = sorted(self._unsupported_events.intersection(requested_events))
+        if bad:
+            return {"valid": False, "error_message": f"Unsupported perf events: {', '.join(bad)}"}
+        return {"valid": True, "error_message": None}
+
+
+def _start_request(**overrides) -> ProfilingRequest:
+    data = {
+        "service_name": "svc-a",
+        "request_type": "start",
+        "target_scope": "host",
+        "target_hosts": {"host-a": None},
+    }
+    data.update(overrides)
+    return ProfilingRequest(**data)
+
+
+def _bulk(*requests) -> BulkProfilingRequest:
+    return BulkProfilingRequest(requests=list(requests))
+
+
+def _perf_args(events, mode="enabled_restricted"):
+    return {"profiler_configs": {"perf": {"mode": mode, "events": events}}}
+
+
+# ---------------------------------------------------------------------------
+# AT-S9 — PMU validation
+# ---------------------------------------------------------------------------
+
+
+class TestPmuValidationSpec:
+    def test_supported_events_pass(self):
+        db = FakeDBManager(unsupported_events=[])
+        req = _start_request(additional_args=_perf_args(["cycles", "instructions"]))
+        ok, err = validate_pmu_events(_bulk(req), db)
+        assert ok is True
+        assert err is None
+
+    def test_unsupported_event_is_rejected_with_clear_error(self):
+        db = FakeDBManager(unsupported_events=["cache-misses"])
+        req = _start_request(additional_args=_perf_args(["cycles", "cache-misses"]))
+        ok, err = validate_pmu_events(_bulk(req), db)
+        assert ok is False
+        assert "svc-a" in err
+        assert "cache-misses" in err
+
+    def test_perf_disabled_skips_pmu_validation(self):
+        db = FakeDBManager(unsupported_events=["cache-misses"])
+        req = _start_request(additional_args=_perf_args(["cache-misses"], mode="disabled"))
+        ok, err = validate_pmu_events(_bulk(req), db)
+        assert ok is True and err is None
+
+    def test_stop_requests_are_not_pmu_validated(self):
+        db = FakeDBManager(unsupported_events=["cache-misses"])
+        req = ProfilingRequest(
+            service_name="svc-a",
+            request_type="stop",
+            target_scope="host",
+            stop_level="host",
+            target_hosts={"host-a": None},
+            additional_args=_perf_args(["cache-misses"]),
+        )
+        ok, err = validate_pmu_events(_bulk(req), db)
+        assert ok is True and err is None
+
+    def test_workload_scope_without_target_hosts_does_not_crash(self):
+        # AT-S9 for non-host scopes: target_hosts is None; events are validated
+        # against the whole service instead of blowing up on None.keys().
+        db = FakeDBManager(unsupported_events=[])
+        req = _start_request(
+            target_scope="service",
+            target_hosts=None,
+            target_entities=[{"service_name": "svc-a"}],
+            additional_args=_perf_args(["cycles"]),
+        )
+        ok, err = validate_pmu_events(_bulk(req), db)
+        assert ok is True and err is None
+
+
+# ---------------------------------------------------------------------------
+# Capacity guardrails
+# ---------------------------------------------------------------------------
+
+
+class TestCapacitySpec:
+    def test_within_capacity_passes(self):
+        # 100 active hosts, 10% cap => 10 allowed; request of 1 with 0 already profiling.
+        db = FakeDBManager(active_hosts=100, profiling_total=0, profiling_outside=0)
+        req = _start_request(target_hosts={"host-a": None})
+        ok, err, hosts = validate_profiling_capacity(_bulk(req), db)
+        assert ok is True
+        assert err is None
+        assert hosts == ["host-a"]
+
+    def test_exceeding_percentage_capacity_is_rejected(self):
+        # 100 active hosts, 10% cap => 10 allowed; 10 already profiling outside selection
+        # + 1 new = 11 > 10 => rejected.
+        db = FakeDBManager(active_hosts=100, profiling_total=10, profiling_outside=10)
+        req = _start_request(target_hosts={"host-new": None})
+        ok, err, _ = validate_profiling_capacity(_bulk(req), db)
+        assert ok is False
+        assert "capacity exceeded" in err.lower()
+
+    def test_request_size_limit_is_rejected(self):
+        db = FakeDBManager(active_hosts=10_000)
+        many_hosts = {f"host-{i}": None for i in range(21)}  # MAX_PROFILING_REQUEST_HOSTS default = 20
+        req = _start_request(target_hosts=many_hosts)
+        ok, err, _ = validate_profiling_capacity(_bulk(req), db)
+        assert ok is False
+        assert "request size exceeded" in err.lower()
+
+    def test_stop_only_bulk_skips_capacity(self):
+        db = FakeDBManager(active_hosts=0)
+        stop = ProfilingRequest(
+            service_name="svc-a",
+            request_type="stop",
+            target_scope="host",
+            stop_level="host",
+            target_hosts={"host-a": None},
+        )
+        ok, err, _ = validate_profiling_capacity(_bulk(stop), db)
+        assert ok is True and err is None

--- a/src/tests/spec/backend/test_profiling_request_spec.py
+++ b/src/tests/spec/backend/test_profiling_request_spec.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""
+Acceptance / spec tests for the ProfilingRequest validation contract.
+
+Unlike the sibling ``test_metrics_profile_request.py`` (which drives a *live*
+backend over HTTP), these tests import the ``ProfilingRequest`` pydantic model
+directly and exercise its validation rules in-process. They are fast, need no
+running server or database, and serve as the executable specification for the
+start/stop targeting rules.
+
+The central invariant (which the host/service stop regression violated):
+
+    A host-/service-level STOP must not carry any PID — neither in
+    ``target_hosts`` nor via a ``target_entities`` selector. The frontend
+    request builder is expected to produce payloads that satisfy this spec
+    (see ``profilingRequestBuilder.mjs`` / ``profilingRequestBuilder.test.mjs``).
+
+Run just this file:
+
+    cd src && python -m pytest tests/unit/backend/test_profiling_request_spec.py -v
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the backend + gprofiler_dev packages importable without a full install:
+#   .../src/gprofiler      contains the ``backend`` package
+#   .../src/gprofiler-dev  contains the ``gprofiler_dev`` package
+_SRC_ROOT = Path(__file__).resolve().parents[3]
+for _pkg_root in (_SRC_ROOT / "gprofiler", _SRC_ROOT / "gprofiler-dev"):
+    if str(_pkg_root) not in sys.path:
+        sys.path.insert(0, str(_pkg_root))
+
+# Skip cleanly if backend deps (pydantic, humps, ...) are not installed here.
+pytest.importorskip("pydantic", reason="pydantic is required for the ProfilingRequest spec tests")
+pytest.importorskip("humps", reason="pyhumps is required for the ProfilingRequest spec tests")
+
+try:
+    from pydantic import ValidationError
+    from backend.models.metrics_models import ProfilingRequest
+except Exception as exc:  # pragma: no cover - environment guard
+    pytest.skip(f"backend.models.metrics_models not importable: {exc}", allow_module_level=True)
+
+
+def _base(**overrides):
+    """A minimal valid request skeleton; override per-case."""
+    data = {
+        "service_name": "svc-a",
+        "request_type": "start",
+        "target_scope": "host",
+        "target_hosts": {"host-a": None},
+    }
+    data.update(overrides)
+    return data
+
+
+def _make(**overrides) -> ProfilingRequest:
+    return ProfilingRequest(**_base(**overrides))
+
+
+def _entity(**fields):
+    """Build a target_entities selector dict (snake_case field names)."""
+    return {"service_name": "svc-a", **fields}
+
+
+# ---------------------------------------------------------------------------
+# Host-/service-level STOP — the regression surface
+# ---------------------------------------------------------------------------
+
+
+class TestHostLevelStopSpec:
+    def test_host_stop_without_pids_is_valid(self):
+        req = _make(
+            request_type="stop",
+            target_scope="host",
+            stop_level="host",
+            target_hosts={"host-a": None},
+            target_entities=[_entity(hostname="host-a")],
+        )
+        assert req.request_type == "stop"
+        assert req.stop_level == "host"
+
+    def test_service_stop_without_pids_is_valid(self):
+        req = _make(
+            request_type="stop",
+            target_scope="service",
+            stop_level="host",
+            target_hosts=None,
+            target_entities=[_entity(hostname="host-a")],
+        )
+        assert req.stop_level == "host"
+
+    def test_host_stop_with_pids_in_target_hosts_is_rejected(self):
+        with pytest.raises(ValidationError, match="No PIDs should be provided"):
+            _make(
+                request_type="stop",
+                target_scope="host",
+                stop_level="host",
+                target_hosts={"host-a": [4242]},
+            )
+
+    def test_host_stop_with_pid_in_target_entity_is_rejected(self):
+        # This is exactly what the buggy frontend used to send.
+        with pytest.raises(ValidationError, match="No PIDs should be provided"):
+            _make(
+                request_type="stop",
+                target_scope="host",
+                stop_level="host",
+                target_hosts={"host-a": None},
+                target_entities=[_entity(hostname="host-a", pid=4242)],
+            )
+
+    def test_host_stop_with_pid_zero_in_entity_is_rejected(self):
+        # A PID of 0 still counts as "a PID was provided" for a host-level stop.
+        with pytest.raises(ValidationError, match="No PIDs should be provided"):
+            _make(
+                request_type="stop",
+                target_scope="host",
+                stop_level="host",
+                target_hosts={"host-a": None},
+                target_entities=[_entity(hostname="host-a", pid=0)],
+            )
+
+
+# ---------------------------------------------------------------------------
+# Process-level STOP
+# ---------------------------------------------------------------------------
+
+
+class TestProcessLevelStopSpec:
+    def test_process_stop_with_pids_in_target_hosts_is_valid(self):
+        req = _make(
+            request_type="stop",
+            target_scope="process",
+            stop_level="process",
+            target_hosts={"host-a": [4242]},
+        )
+        assert req.stop_level == "process"
+
+    def test_process_stop_with_pid_in_entity_is_valid(self):
+        req = _make(
+            request_type="stop",
+            target_scope="process",
+            stop_level="process",
+            target_hosts=None,
+            target_entities=[_entity(hostname="host-a", pid=4242, process_name="python")],
+        )
+        assert req.stop_level == "process"
+
+    def test_process_stop_without_any_pid_is_rejected(self):
+        with pytest.raises(ValidationError, match="At least one PID or workload selector"):
+            _make(
+                request_type="stop",
+                target_scope="process",
+                stop_level="process",
+                target_hosts={"host-a": None},
+            )
+
+
+# ---------------------------------------------------------------------------
+# START requests are unaffected by the PID rules
+# ---------------------------------------------------------------------------
+
+
+class TestStartSpec:
+    def test_start_with_target_hosts_is_valid(self):
+        req = _make(request_type="start", target_scope="host", target_hosts={"host-a": None})
+        assert req.request_type == "start"
+
+    def test_start_with_entities_carrying_pid_is_valid(self):
+        # PID rules only apply to stop requests, so a start is fine either way.
+        req = _make(
+            request_type="start",
+            target_scope="process",
+            target_hosts=None,
+            target_entities=[_entity(hostname="host-a", pid=4242)],
+        )
+        assert req.request_type == "start"
+
+
+# ---------------------------------------------------------------------------
+# Shared targeting requirements
+# ---------------------------------------------------------------------------
+
+
+class TestTargetingRequirementsSpec:
+    def test_request_without_any_target_is_rejected(self):
+        with pytest.raises(ValidationError, match="At least one target_hosts entry or target_entities"):
+            ProfilingRequest(
+                service_name="svc-a",
+                request_type="start",
+                target_scope="host",
+                target_hosts=None,
+                target_entities=None,
+            )
+
+    @pytest.mark.parametrize("bad_scope", ["cluster", "", "HOST"])
+    def test_invalid_target_scope_is_rejected(self, bad_scope):
+        with pytest.raises(ValidationError):
+            _make(target_scope=bad_scope)
+
+    @pytest.mark.parametrize("bad_stop_level", ["node", "pod", ""])
+    def test_invalid_stop_level_is_rejected(self, bad_stop_level):
+        with pytest.raises(ValidationError):
+            _make(request_type="stop", stop_level=bad_stop_level, target_hosts={"host-a": None})

--- a/src/tests/spec/conftest.py
+++ b/src/tests/spec/conftest.py
@@ -1,0 +1,34 @@
+#
+# Copyright (C) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Shared setup for the *fast* backend unit/acceptance tests.
+
+These tests import backend modules in-process (no running server or database),
+so they need the ``backend`` and ``gprofiler_dev`` packages importable. This
+conftest makes both source roots available on sys.path before collection.
+"""
+
+import sys
+from pathlib import Path
+
+# src/tests/unit/ -> parents[2] == src/
+_SRC_ROOT = Path(__file__).resolve().parents[2]
+
+for _pkg_root in (_SRC_ROOT / "gprofiler", _SRC_ROOT / "gprofiler-dev"):
+    _path = str(_pkg_root)
+    if _pkg_root.is_dir() and _path not in sys.path:
+        sys.path.insert(0, _path)


### PR DESCRIPTION
## Summary
- persist workload metadata from agent heartbeats and add a workload-aware profiling spec for future spec-driven development
- resolve namespace, pod, container, and process selections into host and PID targets in the backend without replacing the existing command queue
- update the profiling console with workload tabs, richer filters, and workload-aware confirmation summaries

## Test plan
- [x] `python3 -m compileall src/gprofiler/backend/models/metrics_models.py src/gprofiler/backend/routers/metrics_routes.py src/gprofiler-dev/gprofiler_dev/postgres/db_manager.py`
- [x] `git diff --check`
- [ ] Run backend/UI smoke test against a local Performance Studio stack
- [ ] Run DB-backed integration tests with a configured local PostgreSQL instance

Made with [Cursor](https://cursor.com)