### PR TITLE
Add Java async-profiler mode selection for dynamic profiling

### DIFF
--- a/heartbeat_doc/README_HEARTBEAT.md
+++ b/heartbeat_doc/README_HEARTBEAT.md
@@ -196,7 +196,7 @@ The `profiler_configs` key inside `additional_args` controls which profilers are
   "async_profiler": {
     "enabled": true,
     "time": "cpu",
-    "alloc_interval": "2mb"
+    "alloc_interval": "2MB"
   }
 }
 ```
@@ -205,7 +205,7 @@ The `profiler_configs` key inside `additional_args` controls which profilers are
 |---|---|---|---|
 | `enabled` | `true` | `true` / `false` | Set `false` to disable Java profiling entirely |
 | `time` | `"cpu"` | `"cpu"`, `"itimer"`, `"wall"`, `"auto"`, `"alloc"` | Profiling mode for async-profiler (see table below) |
-| `alloc_interval` | `"2mb"` | non-empty string e.g. `"2mb"`, `"512kb"` | Allocation interval; **required** when `time` is `"alloc"` |
+| `alloc_interval` | `"2MB"` | valid size string using bitmath notation e.g. `"2MB"`, `"512KiB"`, `"1GiB"` | Allocation interval; **required** when `time` is `"alloc"` |
 
 | `time` value | Description |
 |---|---|
@@ -215,7 +215,7 @@ The `profiler_configs` key inside `additional_args` controls which profilers are
 | `"auto"` | Auto-select between `cpu` and `itimer` at runtime based on host capabilities |
 | `"alloc"` | Allocation profiling — samples on heap allocations instead of time; `alloc_interval` controls the sampling granularity |
 
-> **Validation:** The server rejects any `time` value outside the five listed above with HTTP 422. For `"alloc"` mode, an empty or absent `alloc_interval` is also rejected.
+> **Validation:** The server rejects any `time` value outside the five listed above with HTTP 422. For `"alloc"` mode, `alloc_interval` must be a non-empty, parseable size string in bitmath notation (e.g. `"2MB"`, `"512KiB"`, `"1GiB"`); absent, empty, or malformed values (e.g. `"2 bananas"`, `"2mb"`) are rejected with HTTP 422.
 
 **Other profilers** (`perf`, `pyperf`, `pyspy`, `phpspy`, `rbspy`, `dotnet_trace`, `nodejs_perf`) are unchanged and described in the Agent Integration section.
 
@@ -571,7 +571,7 @@ curl -X POST http://localhost:8000/api/metrics/profile_request \
     "target_hosts": {"web-01": null},
     "additional_args": {
       "profiler_configs": {
-        "async_profiler": { "enabled": true, "time": "alloc", "alloc_interval": "2mb" }
+        "async_profiler": { "enabled": true, "time": "alloc", "alloc_interval": "2MB" }
       }
     }
   }'

--- a/heartbeat_doc/README_HEARTBEAT.md
+++ b/heartbeat_doc/README_HEARTBEAT.md
@@ -185,6 +185,40 @@ Content-Type: application/json
 | `additional_args` | no | `{}` | Merged flat into `combined_config` |
 | `dry_run` | no | `false` | Validates and returns a response without writing to the database |
 
+#### `additional_args.profiler_configs`
+
+The `profiler_configs` key inside `additional_args` controls which profilers are enabled and how they run. All keys are optional; omitting a key uses the profiler's default.
+
+**Async Profiler (Java)**
+
+```json
+"profiler_configs": {
+  "async_profiler": {
+    "enabled": true,
+    "time": "cpu",
+    "alloc_interval": "2mb"
+  }
+}
+```
+
+| Field | Default | Values | Notes |
+|---|---|---|---|
+| `enabled` | `true` | `true` / `false` | Set `false` to disable Java profiling entirely |
+| `time` | `"cpu"` | `"cpu"`, `"itimer"`, `"wall"`, `"auto"`, `"alloc"` | Profiling mode for async-profiler (see table below) |
+| `alloc_interval` | `"2mb"` | non-empty string e.g. `"2mb"`, `"512kb"` | Allocation interval; **required** when `time` is `"alloc"` |
+
+| `time` value | Description |
+|---|---|
+| `"cpu"` | CPU time — samples only while the thread is on-CPU |
+| `"itimer"` | Interval timer — uses OS `SIGPROF`; lower overhead than `cpu` |
+| `"wall"` | Wall-clock time — includes threads blocked on I/O or locks |
+| `"auto"` | Auto-select between `cpu` and `itimer` at runtime based on host capabilities |
+| `"alloc"` | Allocation profiling — samples on heap allocations instead of time; `alloc_interval` controls the sampling granularity |
+
+> **Validation:** The server rejects any `time` value outside the five listed above with HTTP 422. For `"alloc"` mode, an empty or absent `alloc_interval` is also rejected.
+
+**Other profilers** (`perf`, `pyperf`, `pyspy`, `phpspy`, `rbspy`, `dotnet_trace`, `nodejs_perf`) are unchanged and described in the Agent Integration section.
+
 **Response:**
 
 ```json
@@ -493,6 +527,8 @@ python3 gprofiler/main.py \
 
 ### 1. Create Profiling Request
 
+Basic request (defaults):
+
 ```bash
 curl -X POST http://localhost:8000/api/metrics/profile_request \
   -H "Content-Type: application/json" \
@@ -502,6 +538,42 @@ curl -X POST http://localhost:8000/api/metrics/profile_request \
     "duration": 120,
     "target_hosts": {"web-01": null, "web-02": null},
     "profiling_mode": "cpu"
+  }'
+```
+
+With explicit async-profiler mode (wall-clock):
+
+```bash
+curl -X POST http://localhost:8000/api/metrics/profile_request \
+  -H "Content-Type: application/json" \
+  -d '{
+    "service_name": "web-service",
+    "request_type": "start",
+    "duration": 120,
+    "target_hosts": {"web-01": null},
+    "additional_args": {
+      "profiler_configs": {
+        "async_profiler": { "enabled": true, "time": "wall" }
+      }
+    }
+  }'
+```
+
+Allocation profiling:
+
+```bash
+curl -X POST http://localhost:8000/api/metrics/profile_request \
+  -H "Content-Type: application/json" \
+  -d '{
+    "service_name": "web-service",
+    "request_type": "start",
+    "duration": 60,
+    "target_hosts": {"web-01": null},
+    "additional_args": {
+      "profiler_configs": {
+        "async_profiler": { "enabled": true, "time": "alloc", "alloc_interval": "2mb" }
+      }
+    }
   }'
 ```
 

--- a/src/gprofiler/backend/routers/metrics_routes.py
+++ b/src/gprofiler/backend/routers/metrics_routes.py
@@ -45,7 +45,7 @@ from backend.models.metrics_models import (
     ProfilingResponse,
     SampleCount,
 )
-from backend.utils.dynamic_profiling_utils import validate_profiling_capacity, validate_pmu_events
+from backend.utils.dynamic_profiling_utils import validate_profiling_capacity, validate_pmu_events, validate_async_profiler_config
 from backend.utils.filters_utils import get_rql_first_eq_key, get_rql_only_for_one_key, get_rql_all_eq_values
 from backend.utils.notifications import SlackNotifier
 from backend.utils.request_utils import flamegraph_base_request_params, get_metrics_response, get_query_response
@@ -535,6 +535,28 @@ def create_bulk_profiling_requests(bulk_request: BulkProfilingRequest) -> BulkPr
                 f"Bulk profiling capacity validation failed: {error_message}"
             )
             # Return structured error response
+            return JSONResponse(
+                status_code=422,
+                content={
+                    "detail": [
+                        {
+                            "loc": ["body", "requests"],
+                            "msg": error_message,
+                            "type": "value_error"
+                        }
+                    ]
+                }
+            )
+
+        # Validate async profiler config across all requests
+        is_valid, error_message = validate_async_profiler_config(
+            bulk_profiling_request=bulk_request
+        )
+
+        if not is_valid:
+            logger.warning(
+                f"Async profiler config validation failed: {error_message}"
+            )
             return JSONResponse(
                 status_code=422,
                 content={

--- a/src/gprofiler/backend/utils/dynamic_profiling_utils.py
+++ b/src/gprofiler/backend/utils/dynamic_profiling_utils.py
@@ -16,6 +16,8 @@
 
 from typing import List, Optional
 
+import bitmath
+
 from backend.config import MAX_SIMULTANEOUS_PROFILING_HOSTS_PERCENT, MAX_PROFILING_REQUEST_HOSTS
 from backend.models.metrics_models import BulkProfilingRequest
 
@@ -214,11 +216,20 @@ def validate_async_profiler_config(bulk_profiling_request: BulkProfilingRequest)
 
         if time_mode == "alloc":
             alloc_interval = async_profiler_config.get("alloc_interval", "")
-            if not isinstance(alloc_interval, str) or not alloc_interval.strip():
+            if not isinstance(alloc_interval, str) or not alloc_interval:
                 errors.append(
                     f"Service '{profiling_request.service_name}': "
-                    "alloc_interval must be a non-empty string (e.g. '2mb', '512kb') "
-                    "when async_profiler time mode is 'alloc'."
+                    f"Invalid alloc_interval value {alloc_interval!r}: "
+                    "must be a non-empty string (e.g. '2MB', '512KiB')"
+                )
+                continue
+            try:
+                bitmath.parse_string(alloc_interval)
+            except ValueError:
+                errors.append(
+                    f"Service '{profiling_request.service_name}': "
+                    f"Could not parse alloc_interval {alloc_interval!r}: "
+                    "must be a number followed by a size unit (e.g. '2MB', '512KiB')"
                 )
 
     if errors:

--- a/src/gprofiler/backend/utils/dynamic_profiling_utils.py
+++ b/src/gprofiler/backend/utils/dynamic_profiling_utils.py
@@ -173,3 +173,55 @@ def validate_pmu_events(
         return False, combined_error
     
     return True, None
+
+
+_VALID_AP_TIME_MODES = frozenset({"cpu", "itimer", "wall", "auto", "alloc"})
+
+
+def validate_async_profiler_config(bulk_profiling_request: BulkProfilingRequest) -> tuple[bool, Optional[str]]:
+    """
+    Validate the async_profiler config in each profiling request's additional_args.
+
+    Checks that:
+    - async_profiler.time is one of the supported modes
+    - alloc_interval is a non-empty string when time == 'alloc'
+
+    Returns:
+        tuple: (is_valid: bool, error_message: Optional[str])
+    """
+    errors = []
+
+    for profiling_request in bulk_profiling_request.requests:
+        if profiling_request.request_type != "start" or not profiling_request.additional_args:
+            continue
+
+        profiler_configs = profiling_request.additional_args.get("profiler_configs", {})
+        async_profiler_config = profiler_configs.get("async_profiler")
+        if not isinstance(async_profiler_config, dict):
+            continue
+
+        if not async_profiler_config.get("enabled", True):
+            continue
+
+        time_mode = async_profiler_config.get("time", "cpu")
+        if time_mode not in _VALID_AP_TIME_MODES:
+            errors.append(
+                f"Service '{profiling_request.service_name}': "
+                f"Invalid async_profiler time mode {time_mode!r}. "
+                f"Valid modes: {sorted(_VALID_AP_TIME_MODES)}"
+            )
+            continue
+
+        if time_mode == "alloc":
+            alloc_interval = async_profiler_config.get("alloc_interval", "")
+            if not isinstance(alloc_interval, str) or not alloc_interval.strip():
+                errors.append(
+                    f"Service '{profiling_request.service_name}': "
+                    "alloc_interval must be a non-empty string (e.g. '2mb', '512kb') "
+                    "when async_profiler time mode is 'alloc'."
+                )
+
+    if errors:
+        return False, "\n\n".join(errors)
+
+    return True, None

--- a/src/gprofiler/frontend/src/components/console/ProfilingStatusPage.jsx
+++ b/src/gprofiler/frontend/src/components/console/ProfilingStatusPage.jsx
@@ -172,7 +172,7 @@ const ProfilingStatusPage = () => {
         async_profiler: {
             enabled: true,
             time: 'cpu', // 'cpu', 'itimer', 'wall', 'auto', 'alloc'
-            alloc_interval: '2mb' // used only when time === 'alloc'
+            alloc_interval: '2MB' // used only when time === 'alloc'
         },
         pyperf: 'enabled', // 'enabled', 'disabled'
         pyspy: 'enabled_fallback', // 'enabled_fallback', 'enabled', 'disabled'
@@ -722,7 +722,7 @@ const ProfilingStatusPage = () => {
                                                 profilerConfigs.async_profiler.time === 'wall' ? 'Wall Time' :
                                                 profilerConfigs.async_profiler.time === 'itimer' ? 'ITimer' :
                                                 profilerConfigs.async_profiler.time === 'auto' ? 'Auto' :
-                                                profilerConfigs.async_profiler.time === 'alloc' ? `Allocation (${profilerConfigs.async_profiler.alloc_interval || '2mb'})` :
+                                                profilerConfigs.async_profiler.time === 'alloc' ? `Allocation (${profilerConfigs.async_profiler.alloc_interval || '2MB'})` :
                                                 'CPU Time'
                                             })`
                                             : 'Disabled'

--- a/src/gprofiler/frontend/src/components/console/ProfilingStatusPage.jsx
+++ b/src/gprofiler/frontend/src/components/console/ProfilingStatusPage.jsx
@@ -171,7 +171,8 @@ const ProfilingStatusPage = () => {
         },
         async_profiler: {
             enabled: true,
-            time: 'cpu' // 'cpu' or 'wall'
+            time: 'cpu', // 'cpu', 'itimer', 'wall', 'auto', 'alloc'
+            alloc_interval: '2mb' // used only when time === 'alloc'
         },
         pyperf: 'enabled', // 'enabled', 'disabled'
         pyspy: 'enabled_fallback', // 'enabled_fallback', 'enabled', 'disabled'
@@ -717,7 +718,13 @@ const ProfilingStatusPage = () => {
                                     }</Typography>
                                     <Typography variant="body2">• Java Async Profiler: {
                                         profilerConfigs.async_profiler?.enabled 
-                                            ? `Enabled (${profilerConfigs.async_profiler.time === 'wall' ? 'Wall Time' : 'CPU Time'})`
+                                            ? `Enabled (${
+                                                profilerConfigs.async_profiler.time === 'wall' ? 'Wall Time' :
+                                                profilerConfigs.async_profiler.time === 'itimer' ? 'ITimer' :
+                                                profilerConfigs.async_profiler.time === 'auto' ? 'Auto' :
+                                                profilerConfigs.async_profiler.time === 'alloc' ? `Allocation (${profilerConfigs.async_profiler.alloc_interval || '2mb'})` :
+                                                'CPU Time'
+                                            })`
                                             : 'Disabled'
                                     }</Typography>
                                     <Typography variant="body2">• Pyperf (Python): {profilerConfigs.pyperf === 'enabled' ? 'Enabled' : 'Disabled'}</Typography>

--- a/src/gprofiler/frontend/src/components/console/header/ProfilingTopPanel.jsx
+++ b/src/gprofiler/frontend/src/components/console/header/ProfilingTopPanel.jsx
@@ -626,15 +626,15 @@ const ProfilingTopPanel = ({
                                                     Allocation Interval:
                                                 </Typography>
                                                 <Tooltip
-                                                    title="Memory allocation interval between samples (e.g. '2mb', '512kb')"
+                                                    title="Allocation interval between heap samples. Use bitmath unit notation: MB, KiB, GiB, etc. (e.g. '2MB', '512KiB')"
                                                     placement="right"
                                                     arrow
                                                 >
                                                     <input
                                                         type="text"
-                                                        value={profilerConfigs.async_profiler?.alloc_interval || '2mb'}
+                                                        value={profilerConfigs.async_profiler?.alloc_interval ?? ''}
                                                         onChange={(e) => handleAsyncProfilerConfigChange('alloc_interval', e.target.value)}
-                                                        placeholder="e.g. 2mb, 512kb"
+                                                        placeholder="e.g. 2MB, 512KiB"
                                                         style={{
                                                             fontSize: '0.75rem',
                                                             padding: '4px 8px',

--- a/src/gprofiler/frontend/src/components/console/header/ProfilingTopPanel.jsx
+++ b/src/gprofiler/frontend/src/components/console/header/ProfilingTopPanel.jsx
@@ -556,6 +556,22 @@ const ProfilingTopPanel = ({
                                                 />
                                             </Tooltip>
                                             <Tooltip 
+                                                title="Interval timer profiling - uses OS timer, lower overhead than CPU mode" 
+                                                placement="right"
+                                                arrow
+                                            >
+                                                <FormControlLabel
+                                                    value="itimer"
+                                                    control={<Radio size="small" />}
+                                                    label={
+                                                        <Typography variant="body2" sx={{ fontSize: '0.75rem' }}>
+                                                            ITimer
+                                                        </Typography>
+                                                    }
+                                                    sx={{ mb: 0.5 }}
+                                                />
+                                            </Tooltip>
+                                            <Tooltip 
                                                 title="Wall clock time profiling - includes waiting/blocking time" 
                                                 placement="right"
                                                 arrow
@@ -571,7 +587,65 @@ const ProfilingTopPanel = ({
                                                     sx={{ mb: 0.5 }}
                                                 />
                                             </Tooltip>
+                                            <Tooltip 
+                                                title="Auto mode - resolves to CPU or ITimer at runtime based on host capabilities" 
+                                                placement="right"
+                                                arrow
+                                            >
+                                                <FormControlLabel
+                                                    value="auto"
+                                                    control={<Radio size="small" />}
+                                                    label={
+                                                        <Typography variant="body2" sx={{ fontSize: '0.75rem' }}>
+                                                            Auto
+                                                        </Typography>
+                                                    }
+                                                    sx={{ mb: 0.5 }}
+                                                />
+                                            </Tooltip>
+                                            <Tooltip 
+                                                title="Allocation profiling - samples on memory allocations instead of time" 
+                                                placement="right"
+                                                arrow
+                                            >
+                                                <FormControlLabel
+                                                    value="alloc"
+                                                    control={<Radio size="small" />}
+                                                    label={
+                                                        <Typography variant="body2" sx={{ fontSize: '0.75rem' }}>
+                                                            Allocation
+                                                        </Typography>
+                                                    }
+                                                    sx={{ mb: 0.5 }}
+                                                />
+                                            </Tooltip>
                                         </RadioGroup>
+                                        {profilerConfigs.async_profiler?.time === 'alloc' && (
+                                            <Box sx={{ mt: 1 }}>
+                                                <Typography variant="body2" sx={{ fontSize: '0.75rem', fontWeight: 500, mb: 0.5 }}>
+                                                    Allocation Interval:
+                                                </Typography>
+                                                <Tooltip
+                                                    title="Memory allocation interval between samples (e.g. '2mb', '512kb')"
+                                                    placement="right"
+                                                    arrow
+                                                >
+                                                    <input
+                                                        type="text"
+                                                        value={profilerConfigs.async_profiler?.alloc_interval || '2mb'}
+                                                        onChange={(e) => handleAsyncProfilerConfigChange('alloc_interval', e.target.value)}
+                                                        placeholder="e.g. 2mb, 512kb"
+                                                        style={{
+                                                            fontSize: '0.75rem',
+                                                            padding: '4px 8px',
+                                                            border: '1px solid #ccc',
+                                                            borderRadius: '4px',
+                                                            width: '120px',
+                                                        }}
+                                                    />
+                                                </Tooltip>
+                                            </Box>
+                                        )}
                                     </Box>
                                 )}
                             </Box>

--- a/src/gprofiler/requirements.txt
+++ b/src/gprofiler/requirements.txt
@@ -25,3 +25,4 @@ fastapi==0.109.0
 uvicorn==0.27.0
 gunicorn==23.0.0
 slack_sdk==3.36.0
+bitmath==2.1.1


### PR DESCRIPTION
# Add Java async-profiler mode selection for dynamic profiling

## Summary

Exposes all five async-profiler time modes (`cpu`, `itimer`, `wall`, `auto`, `alloc`) through the dynamic profiling UI and validates them server-side before commands are dispatched to agents. Previously only `cpu` and `wall` were available.

## Changes

### Frontend

**`ProfilingStatusPage.jsx`**
- Extended the `async_profiler` initial state to include `alloc_interval: '2MB'`, ensuring the allocation interval is always present in the submitted payload (fixes a bug where the displayed default `'2MB'` was a render-only fallback and was omitted from the API call, causing backend validation failures).
- Updated the `time` field comment to list all five valid modes.
- Updated the confirmation-dialog summary to display the correct label for each mode, including the `alloc_interval` value for allocation mode.

**`ProfilingTopPanel.jsx`**
- Expanded the async-profiler **Time Mode** radio group from two options (`cpu`, `wall`) to all five:
  - **CPU Time** (`cpu`) — samples only while the thread is on-CPU
  - **ITimer** (`itimer`) — OS interval timer, lower overhead than CPU mode
  - **Wall Time** (`wall`) — includes threads blocked on I/O or locks
  - **Auto** (`auto`) — resolves to `cpu` or `itimer` at runtime based on host capabilities
  - **Allocation** (`alloc`) — samples on heap allocations
- Added an **Allocation Interval** text input (default `2MB`) that appears only when `alloc` is selected, allowing operators to control the sampling granularity (e.g. `512KiB`, `4MB`).
- Fixed the `value` prop from `|| '2mb'` to `?? ''` so the field can be fully cleared by the user (`||` was re-filling the input on every empty-string render).
- Updated the allocation interval tooltip and placeholder to show bitmath unit notation (`2MB`, `512KiB`) so users know the expected format.

### Backend

**`requirements.txt`**
- Added `bitmath==2.1.1` for strict, purpose-built byte-size string parsing and validation.

**`dynamic_profiling_utils.py`**
- Added `_VALID_AP_TIME_MODES = frozenset({"cpu", "itimer", "wall", "auto", "alloc"})` mirroring the agent constant.
- Added `validate_async_profiler_config(bulk_profiling_request)` — iterates over all `start` requests in a bulk operation and validates:
  - `async_profiler.time` is one of the five supported values (HTTP 422 otherwise).
  - `alloc_interval` is present, non-empty, and a valid parseable size string via `bitmath.parse_string()` (HTTP 422 otherwise). This correctly rejects values like `"2 bananas"` that `humanfriendly.parse_size` would silently accept by prefix-matching `"b"` as bytes.

**`metrics_routes.py`**
- Imported `validate_async_profiler_config` and wired it into the bulk profiling request handler immediately after the existing PMU events validation step, returning a structured 422 response on failure.

### Docs

**`heartbeat_doc/README_HEARTBEAT.md`**
- Added a new **`additional_args.profiler_configs`** subsection under *Create Profiling Request* documenting the full `async_profiler` object shape, all five `time` values with descriptions, the `alloc_interval` field, and the server-side validation rules.
- Expanded the *Data Flow Example* curl snippet into three examples: default request, wall-clock mode, and allocation mode with `alloc_interval`.

## Bug Fixes

**Default `alloc_interval` not sent in payload** — the allocation interval input displayed `'2MB'` via a `|| '2MB'` render-time fallback, but since no `onChange` had fired the value was never written to React state. The submitted payload therefore omitted `alloc_interval` entirely, and the backend defaulted it to `""`, failing the non-empty validation. Fixed by initialising `alloc_interval: '2MB'` in component state.

**Input box resetting to `2MB` when cleared** — the same `|| '2MB'` fallback in the `value` prop caused React to re-render the input as `'2MB'` whenever the field was empty, preventing the user from typing a new value. Fixed by switching to `?? ''` (nullish coalescing), which only falls back on `null`/`undefined`.

**`humanfriendly.parse_size` accepting invalid size strings** — `parse_size` performs prefix-matching on unit symbols, so `"2 bananas"` was silently accepted as 2 bytes (matching `"b"`). Replaced with `bitmath.parse_string()`, which requires an exact unit match and raises `ValueError` for unrecognised units.

## Testing Checklist

- [x] Select each of the five time modes in the UI and verify the correct value appears in the API payload.
- [x] Select **Allocation** mode without changing the interval — confirm the request succeeds with the default `2MB`.
- [x] Clear the Allocation Interval field completely and verify it stays empty (no snap-back to `2MB`).
- [x] Submit `time: "alloc"` with `alloc_interval: ""` via direct API call — confirm HTTP 422.
- [x] Submit `time: "alloc"` with `alloc_interval: "2 bananas"` via direct API call — confirm HTTP 422.
- [x] Submit an unsupported `time` value (e.g. `"none"`) via direct API call — confirm HTTP 422 with a descriptive error.
- [x] Confirm all other profiler modes (perf, python, ruby, etc.) are unaffected.
