### PR TITLE
test(e2e): local end-to-end harness for workload-level profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ featuring advanced flamegraph analysis tools.
 - [Usage](#usage)
 - [Managing the stack](#managing-the-stack)
 - [Local running and development](#local-running-and-development)
+- [End-to-end test harness](#end-to-end-test-harness)
 
 
 ## System Overview
@@ -278,3 +279,16 @@ To develop the project, it may be useful to run each component locally, see rele
 - [webapp (backend and frontend)](src/gprofiler/README.md)
 - [gprofiler_flamedb_rest](src/gprofiler_flamedb_rest/README.md)
 - [gprofiler_indexer](src/gprofiler_indexer/README.md)
+
+## End-to-end test harness
+To run the full stack **plus a real gProfiler agent** locally (LocalStack S3/SQS
+included) and exercise the workload-level profiling flow end to end — with API
+acceptance tests (AT-S1..S15) and Playwright UI tests — see
+[deploy/E2E_HARNESS.md](deploy/E2E_HARNESS.md).
+
+```bash
+cd deploy
+make -f Makefile.e2e e2e-up-src    # studio + sample workload + source-built agent
+make -f Makefile.e2e e2e-test      # API acceptance suite
+make -f Makefile.e2e e2e-ui-test   # Playwright UI suite
+```

--- a/deploy/E2E_HARNESS.md
+++ b/deploy/E2E_HARNESS.md
@@ -1,0 +1,244 @@
+# End-to-end test harness (Performance Studio + real gProfiler agent)
+
+This harness runs the **full** Performance Studio stack **plus a real gProfiler
+agent** locally, so the dynamic/workload-level profiling flow can be exercised
+end to end — including the S3 → SQS → indexer → ClickHouse → flamegraph pipeline
+that the studio-only setup never touches.
+
+```
+ e2e-sample-app (CPU workload)
+        ▲ profiled by
+ gprofiler-agent ──heartbeat/commands──► webapp (backend)  ──► Postgres
+        │                                     │
+        └──upload profile (/api/v2/profiles)──┘
+                                              ▼
+                                    S3 (LocalStack) ──► SQS (LocalStack)
+                                                          ▼
+                                             ch-indexer ──► ClickHouse (flamedb)
+                                                          ▼
+                                              UI / flamegraph API (nginx :4433)
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `docker-compose.e2e.yml` | Overlay adding `e2e-sample-app`, `gprofiler-agent`, `e2e-tests`, `e2e-ui-tests` |
+| `Makefile.e2e` | `up / up-src / status / start / stop / flamegraph / test / ui-test / down` targets |
+| `e2e/agent-glibc.Dockerfile` | Wraps a source-built (`--fast`) agent exe in a glibc base |
+| `../src/tests/e2e/` | In-network pytest API acceptance runner (AT-S1..S15) |
+| `../src/tests/playwright/` | Playwright UI acceptance runner |
+
+## Container architecture
+
+**It is not one container and not a Kubernetes pod.** It is a set of independent
+Docker containers wired together by Docker Compose on a single user-defined
+bridge network (`<project>_default`, i.e. `deploy_default`). Each service is its
+own container running one process; they find each other by **service name** as a
+DNS hostname on that network. There is no orchestrator (no k8s, no pod spec) —
+just Compose.
+
+| Container | Image / build | Role |
+|-----------|---------------|------|
+| `gprofiler-ps-webapp` | built from `../src` | FastAPI backend + built UI (heartbeat, profile ingest, status APIs) |
+| `gprofiler-ps-nginx-load-balancer` | `nginx:1.23.3` | TLS + basic-auth edge; publishes `:4433`/`:8443` to the host |
+| `gprofiler-ps-postgres` | `postgres` | heartbeat inventory, profiling requests/commands |
+| `gprofiler-ps-clickhouse` | `clickhouse` | `flamedb` sample/metric storage (profile `with-clickhouse`) |
+| `gprofiler-ps-ch-rest-service` | built | ClickHouse REST facade for the backend |
+| `gprofiler-ps-ch-indexer` | built | **SQS consumer**: reads S3 profiles → writes ClickHouse |
+| `gprofiler-ps-agents-logs-backend` | built | agent log ingest |
+| `gprofiler-ps-periodic-tasks` | built | background jobs |
+| `gprofiler-ps-localstack` | `localstack/localstack:3.0` | **one** container emulating **S3 + SQS** |
+| `gprofiler-ps-e2e-sample-app` | `python:3.11-slim` | deterministic CPU workload to profile *(harness)* |
+| `gprofiler-ps-e2e-agent` | source-built or `GPROFILER_IMAGE` | real gProfiler agent in heartbeat mode *(harness)* |
+| `gprofiler-ps-e2e-tests` | built from `../src/tests/e2e` | pytest API acceptance runner, profile `test` *(harness)* |
+| `gprofiler-ps-e2e-ui-tests` | official Playwright image | Playwright UI runner, profile `ui` *(harness)* |
+
+Only nginx publishes host ports; everything else talks over the internal
+network. The agent, for example, reaches the backend at `http://webapp` directly
+(no host port, no nginx auth).
+
+## S3 + SQS via LocalStack (no AWS account needed)
+
+The `localstack` container runs the S3 and SQS emulators in-process
+(`SERVICES=s3,sqs`) and exposes a single gateway on `:4566`. On startup it runs
+every script in `deploy/localstack_init/` — `01_init_s3_sqs.sh` creates the
+bucket and queue and wires S3 event notifications into SQS. A healthcheck gates
+dependents until both services report `running`.
+
+The pipeline then flows entirely inside the network:
+
+1. agent uploads a profile to `webapp` (`/api/v2/profiles`)
+2. `webapp` writes the object to **S3** (`s3://performance-studio-bucket/...`)
+3. S3 emits an event to **SQS** (`performance-studio-queue`)
+4. `ch-indexer` consumes the SQS message, reads the object, and writes rows to
+   **ClickHouse** (`flamedb.samples`) plus the flamegraph HTML back to S3
+
+All AWS SDK clients in the stack point at `AWS_ENDPOINT_URL=http://localstack:4566`
+with dummy `test`/`test` credentials, so nothing touches real AWS.
+
+## Prerequisites
+
+- **Docker + Docker Compose v2** (Linux, or macOS/Windows via Docker Desktop).
+- The **`gprofiler` agent repo** checked out as a sibling of this repo
+  (`../../gprofiler`) — required for `e2e-up-src` (the portable agent path).
+- **TLS cert + basic-auth file** for nginx (one-time, in `deploy/`):
+
+```bash
+cd deploy
+mkdir -p tls
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout tls/key.pem -out tls/cert.pem
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout tls/ch_rest_key.pem -out tls/ch_rest_cert.pem
+htpasswd -B -C 12 -c .htpasswd admin      # set the password to 'admin' to match the defaults
+```
+
+The harness assumes web creds `admin` / `admin` (override with `AUTH=` on the
+Make targets and the `E2E_BASIC_AUTH_*` env vars).
+
+## Quick start
+
+```bash
+cd deploy
+
+# Bring up studio + sample app + agent (mints a valid profiler token for you).
+make -f Makefile.e2e e2e-up
+
+# See the agent's live inventory row (heartbeat, agent version, status).
+make -f Makefile.e2e e2e-status
+
+# Drive the control plane:
+make -f Makefile.e2e e2e-start     # host-scope START (profiles the sample app)
+make -f Makefile.e2e e2e-stop      # host-scope STOP  (no PIDs at host level)
+
+# Inspect the artifacts the pipeline produced in (Local)S3.
+make -f Makefile.e2e e2e-flamegraph
+
+# Follow the agent.
+make -f Makefile.e2e e2e-agent-logs
+
+# Remove ONLY the harness services (studio keeps running).
+make -f Makefile.e2e e2e-down
+```
+
+`SERVICE=<name>` overrides the target service (default `e2e-sample-app`) on the
+`e2e-start` / `e2e-stop` / `e2e-flamegraph` targets.
+
+## How the agent is wired
+
+- **Endpoint / auth.** The agent points at the *internal* `webapp` service
+  (`--server-host=http://webapp --api-server=http://webapp`), which bypasses the
+  nginx basic-auth that guards the browser UI. Heartbeat/command endpoints don't
+  validate the bearer token locally, but the upload/health-check path *does* — so
+  `e2e-up` mints a real token via `GET /api/api_key` and injects it as
+  `GPROFILER_TOKEN`.
+- **Isolation.** The agent shares only the **sample app's** PID namespace
+  (`pid: "service:e2e-sample-app"`), so it profiles that workload and never the
+  host. `perf` is disabled (`--perf-mode=none`); py-spy profiles the Python
+  workload.
+- **Determinism.** `e2e-sample-app` runs a fixed hot loop, so flamegraphs have
+  stable, recognizable frames.
+
+## Agent image
+
+There are two ways to get the agent image; pick per your goal.
+
+### A) From source, fast (verify your agent changes) — recommended
+
+Uses the agent repo's **`--fast`** executable build, which skips `staticx`
+(the slow bundling step) and finishes in ~1-2 min on a warm Docker cache:
+
+```bash
+make -f Makefile.e2e e2e-up-src        # builds exe (--fast) + wraps + brings up
+# or just rebuild the image:
+make -f Makefile.e2e e2e-agent-build
+```
+
+Because `--fast` skips staticx, the resulting `build/<arch>/gprofiler` is
+**glibc-dynamic** and will *not* run on the alpine base in the repo's
+`container.Dockerfile` (you'd get `exec /gprofiler: No such file or directory`).
+The harness therefore wraps it in a glibc base — see `e2e/agent-glibc.Dockerfile`.
+Override arch/repo with `AGENT_ARCH=` / `AGENT_REPO=` if needed.
+
+### B) Prebuilt image (fastest, no build)
+
+`make -f Makefile.e2e e2e-up` uses `GPROFILER_IMAGE` (default
+`intel/gprofiler:latest`, the upstream public image) with the vanilla
+`/gprofiler` entrypoint. Good for exercising the studio side when you don't need
+agent-source changes. Override it to test a specific build:
+
+```bash
+GPROFILER_IMAGE=intel/gprofiler:1.53.1 make -f Makefile.e2e e2e-up
+```
+
+Agent-side pure-logic changes (heartbeat inventory, command queue) are also
+covered by the fast unit suite in `gprofiler/tests_fast/`.
+
+## Portability (will it work on any engineer's box?)
+
+Yes for **Linux/Ubuntu** with Docker + Compose v2 — that's the primary target and
+where it's verified. Keep these in mind:
+
+- **Agent image.** `e2e-up` defaults to the upstream public `intel/gprofiler:latest`.
+  To verify *your own* agent changes, use `make -f Makefile.e2e e2e-up-src`, which
+  builds the agent from the sibling `../../gprofiler` checkout. Studio images all
+  build from source here, so the studio side is portable as-is.
+- **CPU architecture.** The source build defaults to `x86_64`
+  (`build_x86_64_executable.sh`). On arm64 (Apple Silicon, Graviton) use
+  `AGENT_ARCH=aarch64 make -f Makefile.e2e e2e-up-src` (drives
+  `build_aarch64_executable.sh`); the glibc wrapper honors `AGENT_ARCH`.
+- **Linux vs macOS/Windows.** On Linux the agent's `privileged: true` + shared
+  PID namespace + py-spy `ptrace` work natively. On Docker Desktop
+  (macOS/Windows) everything runs inside its Linux VM and works, but profiling
+  fidelity depends on the VM; `--perf-mode=none` (already set) avoids kernel-perf
+  issues. `pid: "service:..."` is a Compose feature and is portable.
+- **Host ports.** Only nginx publishes ports (`4433`, `8443`). If those clash,
+  remap them in `docker-compose.yml`. The DB ports are intentionally not
+  published (tests run in-network), so there's nothing else to collide.
+- **Compose network name.** Helper targets use `$(NETWORK)`, derived from the
+  project dir (`deploy_default`). If you set `COMPOSE_PROJECT_NAME`, pass
+  `NETWORK=<name>_default`.
+- **Prerequisites** above (TLS + `.htpasswd`) are one-time and cross-platform
+  (need `openssl` + `htpasswd`; `htpasswd` ships with `apache2-utils` on Ubuntu).
+
+## Test layers
+
+1. **Fast unit/spec** (no stack) — PR gate: `gprofiler/tests_fast/` and
+   `gprofiler-performance-studio/src/tests/spec/` + the frontend `node --test`.
+2. **API acceptance** (this harness) — `src/tests/e2e/`, run via
+   `make -f Makefile.e2e e2e-test`. 15 in-network pytest cases covering the
+   spec's **AT-S1 .. AT-S15** against the live stack: inventory/tab-counts (S1–S4),
+   host/service/process resolution + command creation (S5–S7), empty-resolution
+   422 (S8), PMU rejection (S9), continuous subscription auto-enrollment (S10–S13),
+   and legacy/partial-inventory compatibility (S14–S15).
+3. **Full-pipeline smoke** — the real agent path above proves S3/SQS/indexer/
+   ClickHouse/flamegraph (AT-A1–A8). Verified with the source-built agent.
+4. **Playwright UI e2e** — `src/tests/playwright/`, run via
+   `make -f Makefile.e2e e2e-ui-test`. Drives the console through the internal
+   nginx (basic auth + self-signed TLS) using the official Playwright browser
+   image, asserting the start/stop confirmation flow (dry-run validation +
+   submit). The STOP case is the direct UI regression test for the
+   host-level-stop bug.
+
+Run everything against a running stack:
+
+```bash
+make -f Makefile.e2e e2e-up        # or e2e-up-src for the source-built agent
+make -f Makefile.e2e e2e-test      # API acceptance (AT-S1..S15)
+make -f Makefile.e2e e2e-ui-test   # Playwright UI acceptance
+```
+
+## Optional: container/pod inventory
+
+The agent logs `No container runtime found for heartbeat workload inventory`
+because the Docker socket isn't mounted (keeps it isolated from the host). To
+exercise namespace/pod/container scope tabs with a real agent, mount
+`/var/run/docker.sock:/var/run/docker.sock:ro` into `gprofiler-agent` — note this
+gives the agent visibility into all host containers.
+
+## Notes
+
+- `e2e-down` removes only the harness containers (agent, sample app, test/UI
+  runners); use `e2e-down-all` to tear down the entire studio stack (destructive).
+- The compose project name defaults to the directory (`deploy`), so the network
+  is `deploy_default`. Helper targets read `$(NETWORK)`; override with
+  `NETWORK=<project>_default` if you set `COMPOSE_PROJECT_NAME`.

--- a/deploy/E2E_HARNESS.md
+++ b/deploy/E2E_HARNESS.md
@@ -95,6 +95,12 @@ htpasswd -B -C 12 -c .htpasswd admin      # set the password to 'admin' to match
 The harness assumes web creds `admin` / `admin` (override with `AUTH=` on the
 Make targets and the `E2E_BASIC_AUTH_*` env vars).
 
+> **Note:** The `htpasswd` command above uses `-c` which *creates* (or overwrites)
+> `.htpasswd`. If you already have a `.htpasswd` with a different username, the
+> `admin` entry won't be present and every `make` target that calls the nginx API
+> will get a `401`. Either recreate the file with `-c`, or add the entry without
+> overwriting: `htpasswd -B -C 12 -b .htpasswd admin admin`.
+
 ## Quick start
 
 ```bash
@@ -239,6 +245,18 @@ gives the agent visibility into all host containers.
 
 - `e2e-down` removes only the harness containers (agent, sample app, test/UI
   runners); use `e2e-down-all` to tear down the entire studio stack (destructive).
+- **Token minting on cold builds.** `e2e-up` polls the studio API for up to 60 s
+  (30 × 2 s) before minting the agent token. On a cold build the webapp can take
+  longer, leaving the agent container with an empty `GPROFILER_TOKEN` and causing
+  it to crash-loop. If this happens the rest of the stack is still healthy — just
+  re-run the mint + recreate step manually:
+  ```bash
+  tok=$(curl -sk https://localhost:4433/api/api_key -u admin:admin \
+    | python3 -c "import sys,json;print(json.load(sys.stdin)['apiKey'])")
+  GPROFILER_TOKEN="$tok" GPROFILER_IMAGE=gprofiler-e2e-agent:src \
+    docker compose -f docker-compose.yml -f docker-compose.e2e.yml \
+    --profile with-clickhouse up -d --force-recreate gprofiler-agent
+  ```
 - The compose project name defaults to the directory (`deploy`), so the network
   is `deploy_default`. Helper targets read `$(NETWORK)`; override with
   `NETWORK=<project>_default` if you set `COMPOSE_PROJECT_NAME`.

--- a/deploy/Makefile.e2e
+++ b/deploy/Makefile.e2e
@@ -1,0 +1,114 @@
+# E2E harness for Performance Studio + a real gProfiler agent.
+#
+# Usage:
+#   make -f Makefile.e2e e2e-up        # bring up studio + sample app + agent
+#   make -f Makefile.e2e e2e-status    # show the agent in workload_status
+#   make -f Makefile.e2e e2e-start     # submit a host-scope start (SERVICE/HOST overridable)
+#   make -f Makefile.e2e e2e-stop      # submit a host-scope stop
+#   make -f Makefile.e2e e2e-agent-logs
+#   make -f Makefile.e2e e2e-test      # run in-network pytest acceptance suite
+#   make -f Makefile.e2e e2e-down      # remove only the agent + sample app (studio stays up)
+#   make -f Makefile.e2e e2e-down-all  # tear the whole stack down (destructive)
+
+SHELL := /bin/bash
+
+COMPOSE := docker compose -f docker-compose.yml -f docker-compose.e2e.yml --profile with-clickhouse
+NGINX   := https://localhost:4433
+AUTH    := admin:admin
+SERVICE ?= e2e-sample-app
+# Compose default network. Derived from the project name (the deploy/ dir), so
+# override NETWORK=<name>_default if you set COMPOSE_PROJECT_NAME.
+NETWORK ?= $(notdir $(CURDIR))_default
+
+# Source-build settings (sibling agent repo).
+AGENT_REPO      ?= ../../gprofiler
+AGENT_ARCH      ?= x86_64
+AGENT_SRC_IMAGE ?= gprofiler-e2e-agent:src
+
+# Placeholder token so compose can parse before a real one is minted; the agent
+# is re-created with the real token in e2e-up.
+export GPROFILER_TOKEN ?= bootstrap
+
+.PHONY: e2e-up e2e-up-src e2e-agent-build e2e-token e2e-status e2e-start e2e-stop e2e-agent-logs e2e-test e2e-down e2e-down-all e2e-flamegraph
+
+## Build the agent image FROM SOURCE using the fast (no-staticx) build (~1-2 min
+## warm cache). The --fast exe is glibc-dynamic, so it's wrapped in a glibc base.
+e2e-agent-build:
+	@echo ">> building agent executable from source (--fast, no staticx)"
+	cd $(AGENT_REPO) && scripts/build_$(AGENT_ARCH)_executable.sh --fast
+	@echo ">> wrapping exe in glibc base -> $(AGENT_SRC_IMAGE)"
+	docker build -f e2e/agent-glibc.Dockerfile --build-arg ARCH=$(AGENT_ARCH) -t $(AGENT_SRC_IMAGE) $(AGENT_REPO)
+
+## Build the agent from source, then bring the whole harness up with it.
+e2e-up-src: e2e-agent-build
+	GPROFILER_IMAGE=$(AGENT_SRC_IMAGE) $(MAKE) -f Makefile.e2e e2e-up
+
+## Mint (or fetch) a valid profiler token from the running studio.
+e2e-token:
+	@curl -sk $(NGINX)/api/api_key -u $(AUTH) \
+	  | python3 -c "import sys,json;print(json.load(sys.stdin)['apiKey'])"
+
+## Bring the whole stack up, then re-create the agent with a real token.
+e2e-up:
+	@echo ">> starting studio + sample app + agent (bootstrap token)"
+	$(COMPOSE) up -d --build
+	@echo ">> waiting for studio API..."
+	@for i in $$(seq 1 30); do \
+	  if curl -skf $(NGINX)/api/api_key -u $(AUTH) >/dev/null 2>&1; then break; fi; \
+	  sleep 2; \
+	done
+	@tok=$$(curl -sk $(NGINX)/api/api_key -u $(AUTH) | python3 -c "import sys,json;print(json.load(sys.stdin)['apiKey'])"); \
+	 echo ">> minting token: $$tok"; \
+	 GPROFILER_TOKEN=$$tok $(COMPOSE) up -d --force-recreate gprofiler-agent
+	@echo ">> up. Try: make -f Makefile.e2e e2e-status"
+
+## Show the agent's live inventory row.
+e2e-status:
+	@curl -sk "$(NGINX)/api/metrics/profiling/workload_status" -u $(AUTH) \
+	  | python3 -m json.tool
+
+## Submit a host-scope START for $(SERVICE) (auto-discovers the reporting host).
+e2e-start:
+	@host=$$(curl -sk "$(NGINX)/api/metrics/profiling/host_status?service_name=$(SERVICE)" -u $(AUTH) \
+	  | python3 -c "import sys,json;print(json.load(sys.stdin)['hosts'][0]['hostname'])"); \
+	 echo ">> start on host=$$host"; \
+	 curl -sk -X POST "$(NGINX)/api/metrics/profile_request" -u $(AUTH) -H "Content-Type: application/json" \
+	  -d "{\"service_name\":\"$(SERVICE)\",\"request_type\":\"start\",\"continuous\":false,\"duration\":30,\"frequency\":11,\"profiling_mode\":\"cpu\",\"target_scope\":\"host\",\"target_hosts\":{\"$$host\":[]},\"target_entities\":[{\"service_name\":\"$(SERVICE)\",\"hostname\":\"$$host\"}],\"additional_args\":{}}" \
+	 | python3 -m json.tool
+
+## Submit a host-scope STOP for $(SERVICE) (regression check: no PIDs at host level).
+e2e-stop:
+	@host=$$(curl -sk "$(NGINX)/api/metrics/profiling/host_status?service_name=$(SERVICE)" -u $(AUTH) \
+	  | python3 -c "import sys,json;print(json.load(sys.stdin)['hosts'][0]['hostname'])"); \
+	 echo ">> stop on host=$$host"; \
+	 curl -sk -X POST "$(NGINX)/api/metrics/profile_request" -u $(AUTH) -H "Content-Type: application/json" \
+	  -d "{\"service_name\":\"$(SERVICE)\",\"request_type\":\"stop\",\"continuous\":false,\"duration\":30,\"frequency\":11,\"profiling_mode\":\"cpu\",\"target_scope\":\"host\",\"stop_level\":\"host\",\"target_hosts\":{\"$$host\":[]},\"target_entities\":[{\"service_name\":\"$(SERVICE)\",\"hostname\":\"$$host\"}],\"additional_args\":{}}" \
+	 | python3 -m json.tool
+
+## List the flamegraph artifacts produced in (local)S3.
+e2e-flamegraph:
+	@docker run --rm --network $(NETWORK) \
+	  -e AWS_ACCESS_KEY_ID=test -e AWS_SECRET_ACCESS_KEY=test -e AWS_DEFAULT_REGION=us-east-1 \
+	  amazon/aws-cli:2.15.0 --endpoint-url http://localstack:4566 \
+	  s3 ls s3://performance-studio-bucket/products/$(SERVICE)/ --recursive
+
+e2e-agent-logs:
+	@docker logs -f gprofiler-ps-e2e-agent
+
+## Run the in-network acceptance suite (pytest) against the live stack.
+e2e-test:
+	$(COMPOSE) --profile test build e2e-tests
+	$(COMPOSE) --profile test run --rm e2e-tests
+
+## Run the Playwright UI acceptance suite (in-network, official browser image).
+e2e-ui-test:
+	$(COMPOSE) --profile ui build e2e-ui-tests
+	$(COMPOSE) --profile ui run --rm e2e-ui-tests
+
+## Remove only the harness-added services; studio keeps running.
+e2e-down:
+	$(COMPOSE) rm -sf gprofiler-agent e2e-sample-app e2e-tests e2e-ui-tests
+
+## Tear everything down (studio included). Destructive.
+e2e-down-all:
+	$(COMPOSE) down

--- a/deploy/docker-compose.e2e.yml
+++ b/deploy/docker-compose.e2e.yml
@@ -1,0 +1,116 @@
+#
+# E2E overlay for the Performance Studio + gProfiler agent test harness.
+#
+# Layer this on top of the base stack:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.e2e.yml \
+#     --profile with-clickhouse up -d --build
+#
+# It adds:
+#   * e2e-sample-app  - a deterministic CPU-burning workload to profile
+#   * gprofiler-agent - a real gProfiler agent in dynamic/heartbeat mode, pointed
+#                       at the INTERNAL webapp (bypassing nginx basic auth), that
+#                       reports workload inventory and executes start/stop commands
+#   * e2e-tests       - an in-network pytest runner (profile "test"; on demand)
+#
+# The agent profiles only the sample app's PID namespace, so it never touches the
+# host's processes.
+#
+services:
+  # A deterministic target the agent can profile (py-spy sees a hot Python frame).
+  e2e-sample-app:
+    image: python:3.11-slim
+    container_name: gprofiler-ps-e2e-sample-app
+    restart: unless-stopped
+    command:
+      - python3
+      - -c
+      - |
+        import time
+        def hot_loop():
+            total = 0
+            for i in range(5_000_000):
+                total += (i * i) % 7
+            return total
+        while True:
+            hot_loop()
+            time.sleep(0.01)
+
+  # gProfiler agent in dynamic profiling (heartbeat) mode.
+  # Defaults to the upstream public image; override with GPROFILER_IMAGE, or build
+  # from source with `make -f Makefile.e2e e2e-up-src` (see E2E_HARNESS.md).
+  gprofiler-agent:
+    image: ${GPROFILER_IMAGE:-intel/gprofiler:latest}
+    container_name: gprofiler-ps-e2e-agent
+    restart: unless-stopped
+    entrypoint: ["/gprofiler"]
+    # Point at the internal webapp service (no nginx basic auth on the internal
+    # port); the backend does not validate the bearer token locally.
+    command:
+      # --server-host: profile upload + health check; --api-server: heartbeat/metrics.
+      # Both are served by the internal webapp (no nginx basic auth on that port).
+      - --server-host=http://webapp
+      - --api-server=http://webapp
+      # A valid profiler token is required for upload/health-check. Mint one from
+      # the running studio (GET /api/api_key) and export GPROFILER_TOKEN before up.
+      - "--token=${GPROFILER_TOKEN:?set GPROFILER_TOKEN first - use make e2e-up}"
+      - --service-name=e2e-sample-app
+      - --upload-results
+      - --enable-heartbeat-server
+      - --heartbeat-interval=10
+      - --perf-mode=none
+      - --output-dir=/tmp/gprofiler_output
+      - --dont-send-logs
+      # Agent shares the sample app's PID namespace (not host-init), so skip the
+      # init-namespace guard.
+      - --disable-pidns-check
+    privileged: true
+    # Share the sample app's PID namespace so the agent profiles only that
+    # workload (isolated from the host).
+    pid: "service:e2e-sample-app"
+    environment:
+      - GPROFILER_IN_CONTAINER=1
+      - POD_NAMESPACE=e2e
+      - POD_NAME=gprofiler-agent
+    depends_on:
+      - webapp
+      - e2e-sample-app
+
+  # In-network acceptance/UI test runner. Kept behind the "test" profile so it
+  # only runs on demand (e.g. `docker compose ... --profile test run --rm e2e-tests`).
+  e2e-tests:
+    build:
+      context: ../src
+      dockerfile: tests/e2e/Dockerfile
+    container_name: gprofiler-ps-e2e-tests
+    profiles: ["test"]
+    environment:
+      # Reach services by their compose network names.
+      - E2E_BASE_URL=http://webapp
+      - E2E_NGINX_URL=https://nginx-load-balancer
+      - E2E_BASIC_AUTH_USER=admin
+      - E2E_BASIC_AUTH_PASSWORD=admin
+      - GPROFILER_POSTGRES_HOST=$POSTGRES_HOST
+      - GPROFILER_POSTGRES_PORT=$POSTGRES_PORT
+      - GPROFILER_POSTGRES_USERNAME=$POSTGRES_USER
+      - GPROFILER_POSTGRES_PASSWORD=$POSTGRES_PASSWORD
+      - GPROFILER_POSTGRES_DB_NAME=$POSTGRES_DB
+    depends_on:
+      - webapp
+      - db_postgres
+
+  # Playwright UI acceptance runner (profile "ui"; on demand). Reaches the
+  # console via the internal nginx service with basic auth over self-signed TLS.
+  e2e-ui-tests:
+    build:
+      context: ../src/tests/playwright
+      dockerfile: Dockerfile
+    container_name: gprofiler-ps-e2e-ui-tests
+    profiles: ["ui"]
+    environment:
+      - E2E_UI_URL=https://nginx-load-balancer
+      - E2E_BASIC_AUTH_USER=admin
+      - E2E_BASIC_AUTH_PASSWORD=admin
+      - E2E_UI_SERVICE=e2e-sample-app
+    depends_on:
+      - nginx-load-balancer

--- a/deploy/e2e/agent-glibc.Dockerfile
+++ b/deploy/e2e/agent-glibc.Dockerfile
@@ -1,0 +1,19 @@
+# Wraps a locally-built gProfiler executable in a glibc base for the e2e harness.
+#
+# Build context MUST be the gprofiler agent repo root (so build/<arch>/gprofiler
+# is present). Produce that exe first with the fast (no-staticx) build:
+#
+#   cd ../../gprofiler && scripts/build_x86_64_executable.sh --fast
+#
+# The --fast build skips staticx, so the exe is glibc-dynamic and needs a glibc
+# base (ubuntu) rather than the alpine base in the repo's container.Dockerfile.
+ARG ARCH=x86_64
+FROM ubuntu:22.04
+
+ARG ARCH
+ENV GPROFILER_IN_CONTAINER=1
+
+COPY build/${ARCH}/gprofiler /gprofiler
+RUN chmod +x /gprofiler
+
+ENTRYPOINT ["/gprofiler"]

--- a/src/tests/e2e/Dockerfile
+++ b/src/tests/e2e/Dockerfile
@@ -1,0 +1,20 @@
+# In-network acceptance/UI test runner for the e2e harness.
+# Runs pytest (API acceptance) from inside the compose network, so it can reach
+# Postgres/ClickHouse/webapp by service name without exposing host ports.
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /work
+
+# Kept minimal on purpose; extended with playwright in the UI phase.
+RUN pip install --no-cache-dir \
+    pytest==8.2.0 \
+    requests==2.32.3 \
+    psycopg2-binary==2.9.9
+
+# Test sources are mounted or copied at run time.
+COPY tests/e2e /work/tests/e2e
+
+CMD ["pytest", "-q", "tests/e2e"]

--- a/src/tests/e2e/README.md
+++ b/src/tests/e2e/README.md
@@ -1,0 +1,16 @@
+# API acceptance tests (AT-S1 .. AT-S15)
+
+In-network pytest suite that drives the **live** studio stack over HTTP and
+codifies the workload-level profiling acceptance criteria from
+[`heartbeat_doc/WORKLOAD_LEVEL_PROFILING_SPEC.md`](../../../heartbeat_doc/WORKLOAD_LEVEL_PROFILING_SPEC.md).
+
+Do not run these directly — they need the full stack up. Use the e2e harness:
+
+```bash
+cd ../../../deploy
+make -f Makefile.e2e e2e-up        # or e2e-up-src (source-built agent)
+make -f Makefile.e2e e2e-test      # builds this runner and executes it in-network
+```
+
+Full harness docs (topology, LocalStack S3/SQS, portability):
+[`deploy/E2E_HARNESS.md`](../../../deploy/E2E_HARNESS.md).

--- a/src/tests/e2e/conftest.py
+++ b/src/tests/e2e/conftest.py
@@ -1,0 +1,14 @@
+"""Fixtures for the in-network e2e acceptance suite.
+
+Runs from a container on the compose network (see docker-compose.e2e.yml) so
+services are reachable by their compose names (webapp, db_postgres, ...). Also
+works from the host against nginx with basic auth via E2E_* env vars.
+"""
+import pytest
+
+from harness import Client
+
+
+@pytest.fixture(scope="session")
+def client() -> Client:
+    return Client()

--- a/src/tests/e2e/harness.py
+++ b/src/tests/e2e/harness.py
@@ -1,0 +1,211 @@
+"""HTTP harness helpers for the in-network e2e acceptance suite.
+
+The suite drives the *live* studio stack over HTTP (heartbeat ingress, profile
+requests, workload status). It is designed to run from a container on the
+compose network (E2E_BASE_URL=http://webapp, no auth) but also works from the
+host against nginx (E2E_BASE_URL=https://localhost:4433 with basic auth).
+
+Everything is keyed on unique service/host names per test, so runs are isolated
+from each other and from any real agent reporting into the same stack.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
+
+import requests
+import urllib3
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+HEARTBEAT = "/api/metrics/heartbeat"
+PROFILE_REQUEST = "/api/metrics/profile_request"
+PROFILE_REQUEST_BULK = "/api/metrics/profile_request/bulk"
+WORKLOAD_STATUS = "/api/metrics/profiling/workload_status"
+
+# Freshness window used by workload_status (see db_manager: INTERVAL '2 minutes').
+FRESHNESS_SECONDS = 120
+
+
+class Client:
+    """Thin requests wrapper that targets the studio API."""
+
+    def __init__(self) -> None:
+        self.base = os.environ.get("E2E_BASE_URL", "http://webapp").rstrip("/")
+        user = os.environ.get("E2E_BASIC_AUTH_USER")
+        password = os.environ.get("E2E_BASIC_AUTH_PASSWORD")
+        self.auth = (user, password) if user else None
+        self.session = requests.Session()
+
+    def post(self, path: str, payload: Dict[str, Any]) -> requests.Response:
+        return self.session.post(
+            self.base + path, json=payload, auth=self.auth, verify=False, timeout=30
+        )
+
+    def get(self, path: str, params: Optional[Dict[str, Any]] = None) -> requests.Response:
+        return self.session.get(
+            self.base + path, params=params, auth=self.auth, verify=False, timeout=30
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Payload builders
+# --------------------------------------------------------------------------- #
+
+def unique(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:8]}"
+
+
+def process(pid: int, name: str = "java") -> Dict[str, Any]:
+    return {"pid": pid, "process_name": name}
+
+
+def container(
+    container_name: str,
+    processes: Optional[List[Dict[str, Any]]] = None,
+    *,
+    namespace: Optional[str] = None,
+    pod_name: Optional[str] = None,
+    workload_name: Optional[str] = None,
+    workload_kind: Optional[str] = None,
+    container_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    return {
+        "container_id": container_id or unique("cid"),
+        "container_name": container_name,
+        "namespace": namespace,
+        "pod_name": pod_name,
+        "workload_name": workload_name,
+        "workload_kind": workload_kind,
+        "processes": processes or [],
+    }
+
+
+def heartbeat_payload(
+    hostname: str,
+    service_name: str,
+    *,
+    namespace: Optional[str] = None,
+    pod_name: Optional[str] = None,
+    containers: Optional[List[Dict[str, Any]]] = None,
+    perf_supported_events: Optional[List[str]] = None,
+    age_seconds: float = 0.0,
+    agent_version: str = "e2e-1.0.0",
+    run_mode: str = "container",
+    status: str = "idle",
+    last_command_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    ts = datetime.now() - timedelta(seconds=age_seconds)
+    return {
+        "hostname": hostname,
+        "ip_address": "10.0.0.1",
+        "service_name": service_name,
+        "agent_version": agent_version,
+        "run_mode": run_mode,
+        "namespace": namespace,
+        "pod_name": pod_name,
+        "containers": containers or [],
+        "last_command_id": last_command_id,
+        "status": status,
+        "timestamp": ts.isoformat(),
+        "perf_supported_events": perf_supported_events,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# API calls
+# --------------------------------------------------------------------------- #
+
+def send_heartbeat(client: Client, **kwargs: Any) -> Dict[str, Any]:
+    resp = client.post(HEARTBEAT, heartbeat_payload(**kwargs))
+    resp.raise_for_status()
+    return resp.json()
+
+
+def get_workload_status(
+    client: Client, scope: str = "host", service_name: Optional[str] = None
+) -> Dict[str, Any]:
+    params: Dict[str, Any] = {"scope": scope}
+    if service_name:
+        params["service_name"] = service_name
+        params["exact_match"] = "true"
+    resp = client.get(WORKLOAD_STATUS, params=params)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def rows_for(status: Dict[str, Any], service_name: str) -> List[Dict[str, Any]]:
+    """Rows belonging to our service (robust even if server-side filter is loose)."""
+    return [r for r in status.get("rows", []) if r.get("serviceName") == service_name]
+
+
+def _default_entities(service_name, target_scope, target_hosts, target_entities):
+    """The request validator requires at least one target_hosts entry or
+    target_entities selector. For non-host scopes with nothing else provided,
+    mirror the UI by attaching a service selector (resolution uses the request's
+    service_name; the entity just satisfies the contract)."""
+    if target_entities:
+        return target_entities
+    if target_scope != "host" and not target_hosts:
+        return [{"service_name": service_name}]
+    return target_entities
+
+
+def start_request(
+    service_name: str,
+    *,
+    target_scope: str = "host",
+    target_hosts: Optional[Dict[str, List[int]]] = None,
+    target_entities: Optional[List[Dict[str, Any]]] = None,
+    continuous: bool = False,
+    duration: int = 30,
+    frequency: int = 11,
+    additional_args: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    target_entities = _default_entities(service_name, target_scope, target_hosts, target_entities)
+    return {
+        "service_name": service_name,
+        "request_type": "start",
+        "continuous": continuous,
+        "duration": duration,
+        "frequency": frequency,
+        "profiling_mode": "cpu",
+        "target_scope": target_scope,
+        "target_hosts": target_hosts,
+        "target_entities": target_entities,
+        "additional_args": additional_args or {},
+    }
+
+
+def stop_request(
+    service_name: str,
+    *,
+    target_scope: str = "host",
+    stop_level: str = "host",
+    target_hosts: Optional[Dict[str, List[int]]] = None,
+    target_entities: Optional[List[Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    target_entities = _default_entities(service_name, target_scope, target_hosts, target_entities)
+    return {
+        "service_name": service_name,
+        "request_type": "stop",
+        "continuous": False,
+        "duration": 30,
+        "frequency": 11,
+        "profiling_mode": "cpu",
+        "target_scope": target_scope,
+        "stop_level": stop_level,
+        "target_hosts": target_hosts,
+        "target_entities": target_entities,
+        "additional_args": {},
+    }
+
+
+def submit(client: Client, payload: Dict[str, Any]) -> requests.Response:
+    return client.post(PROFILE_REQUEST, payload)
+
+
+def submit_bulk(client: Client, requests_list: List[Dict[str, Any]]) -> requests.Response:
+    return client.post(PROFILE_REQUEST_BULK, {"requests": requests_list})

--- a/src/tests/e2e/test_workload_acceptance.py
+++ b/src/tests/e2e/test_workload_acceptance.py
@@ -1,0 +1,326 @@
+"""End-to-end acceptance tests for workload-level profiling (AT-S1 .. AT-S15).
+
+These drive the *live* studio stack over HTTP and codify the acceptance criteria
+from `heartbeat_doc/WORKLOAD_LEVEL_PROFILING_SPEC.md`. Each test uses a unique
+service/host name so runs are isolated from each other and from any real agent.
+
+Bring the stack up first (see deploy/Makefile.e2e), then:
+
+    make -f Makefile.e2e e2e-test          # in-network
+    # or from host:
+    E2E_BASE_URL=https://localhost:4433 E2E_BASIC_AUTH_USER=admin \
+      E2E_BASIC_AUTH_PASSWORD=admin pytest -q src/tests/e2e
+"""
+import json
+
+import harness as h
+import pytest
+
+
+# --------------------------------------------------------------------------- #
+# Inventory & status views (AT-S1 .. AT-S4)
+# --------------------------------------------------------------------------- #
+
+def test_at_s1_heartbeat_populates_inventory(client):
+    """AT-S1: a fresh heartbeat shows up as a host row in workload_status."""
+    service = h.unique("s1")
+    host = h.unique("host")
+    h.send_heartbeat(
+        client,
+        hostname=host,
+        service_name=service,
+        namespace="obs",
+        pod_name="pod-a",
+        containers=[h.container("app", [h.process(1234)], namespace="obs", pod_name="pod-a")],
+    )
+
+    status = h.get_workload_status(client, scope="host", service_name=service)
+    hosts = {r["hostname"] for r in h.rows_for(status, service)}
+    assert host in hosts
+
+
+def test_at_s2_tab_counts_per_scope(client):
+    """AT-S2: tabCounts reflect distinct groups per scope; activeHosts == hosts."""
+    service = h.unique("s2")
+    host = h.unique("host")
+    h.send_heartbeat(
+        client,
+        hostname=host,
+        service_name=service,
+        namespace="team-a",
+        pod_name="pod-1",
+        containers=[
+            h.container(
+                "checkout",
+                [h.process(11, "java"), h.process(22, "python")],
+                namespace="team-a",
+                pod_name="pod-1",
+                workload_name="checkout",
+                workload_kind="deployment",
+            )
+        ],
+    )
+
+    status = h.get_workload_status(client, scope="host", service_name=service)
+    tabs = status["tabCounts"]
+    assert tabs["service"] == 1
+    assert tabs["host"] == 1
+    assert tabs["namespace"] == 1
+    assert tabs["pod"] == 1
+    assert tabs["container"] == 1
+    assert tabs["process"] == 2
+    assert status["activeHosts"] == 1
+
+
+def test_at_s3_service_tab_grouped_by_service(client):
+    """AT-S3: scope=service returns exactly one aggregated row per service."""
+    service = h.unique("s3")
+    for host in (h.unique("host"), h.unique("host")):
+        h.send_heartbeat(
+            client,
+            hostname=host,
+            service_name=service,
+            containers=[h.container("app", [h.process(1)])],
+        )
+
+    status = h.get_workload_status(client, scope="service", service_name=service)
+    rows = h.rows_for(status, service)
+    assert len(rows) == 1
+    assert rows[0]["hostCount"] == 2
+
+
+def test_at_s4_freshness_filtering(client):
+    """AT-S4: a host whose latest heartbeat is stale is excluded from all tabs."""
+    service = h.unique("s4")
+    host = h.unique("host")
+    # Backdate the heartbeat well beyond the 2-minute freshness window.
+    h.send_heartbeat(
+        client,
+        hostname=host,
+        service_name=service,
+        age_seconds=h.FRESHNESS_SECONDS + 180,
+        containers=[h.container("app", [h.process(1)])],
+    )
+
+    status = h.get_workload_status(client, scope="host", service_name=service)
+    hosts = {r["hostname"] for r in h.rows_for(status, service)}
+    assert host not in hosts
+
+
+# --------------------------------------------------------------------------- #
+# Resolution & command creation (AT-S5 .. AT-S9)
+# --------------------------------------------------------------------------- #
+
+def test_at_s5_host_level_start(client):
+    """AT-S5: a host-scope start yields a start command returned to that host."""
+    service = h.unique("s5")
+    host = h.unique("host")
+    h.send_heartbeat(client, hostname=host, service_name=service)
+
+    resp = h.submit(client, h.start_request(service, target_scope="host", target_hosts={host: []}))
+    assert resp.status_code == 200, resp.text
+
+    beat = h.send_heartbeat(client, hostname=host, service_name=service)
+    assert beat["profiling_command"] is not None
+    assert beat["profiling_command"]["command_type"] == "start"
+
+
+def test_at_s6_service_level_start_fans_out(client):
+    """AT-S6: a service-scope start creates a command for every current host."""
+    service = h.unique("s6")
+    h1, h2 = h.unique("host"), h.unique("host")
+    h.send_heartbeat(client, hostname=h1, service_name=service)
+    h.send_heartbeat(client, hostname=h2, service_name=service)
+
+    resp = h.submit(client, h.start_request(service, target_scope="service"))
+    assert resp.status_code == 200, resp.text
+    assert len(resp.json()["command_ids"]) == 2
+
+    for host in (h1, h2):
+        beat = h.send_heartbeat(client, hostname=host, service_name=service)
+        assert beat["profiling_command"] is not None, f"no command for {host}"
+        assert beat["profiling_command"]["command_type"] == "start"
+
+
+def test_at_s7_process_scope_resolves_to_pids(client):
+    """AT-S7: a process selection resolves to hostname->[pid] and the command carries the PID."""
+    service = h.unique("s7")
+    host = h.unique("host")
+    pid = 4242
+    h.send_heartbeat(
+        client,
+        hostname=host,
+        service_name=service,
+        containers=[h.container("app", [h.process(pid, "java")])],
+    )
+
+    resp = h.submit(
+        client,
+        h.start_request(
+            service,
+            target_scope="process",
+            target_entities=[{"service_name": service, "hostname": host, "pid": pid}],
+        ),
+    )
+    assert resp.status_code == 200, resp.text
+
+    beat = h.send_heartbeat(client, hostname=host, service_name=service)
+    assert beat["profiling_command"] is not None
+    assert str(pid) in json.dumps(beat["profiling_command"]["combined_config"])
+
+
+def test_at_s8_empty_resolution_is_rejected(client):
+    """AT-S8: a selection resolving to zero targets returns 422 and creates no command."""
+    service = h.unique("s8")
+    host = h.unique("host")
+    h.send_heartbeat(
+        client,
+        hostname=host,
+        service_name=service,
+        containers=[h.container("app", [h.process(1234)])],
+    )
+
+    resp = h.submit(
+        client,
+        h.start_request(
+            service,
+            target_scope="process",
+            target_entities=[{"service_name": service, "hostname": host, "pid": 999999}],
+        ),
+    )
+    assert resp.status_code == 422, resp.text
+
+    beat = h.send_heartbeat(client, hostname=host, service_name=service)
+    assert beat["profiling_command"] is None
+
+
+def test_at_s9_pmu_validation_rejects_unsupported_events(client):
+    """AT-S9: a start requesting perf events a host doesn't support is rejected (bulk)."""
+    service = h.unique("s9")
+    host = h.unique("host")
+    h.send_heartbeat(
+        client,
+        hostname=host,
+        service_name=service,
+        perf_supported_events=["cycles"],
+    )
+
+    req = h.start_request(
+        service,
+        target_scope="host",
+        target_hosts={host: []},
+        additional_args={"profiler_configs": {"perf": {"mode": "smart", "events": ["instructions"]}}},
+    )
+    resp = h.submit_bulk(client, [req])
+    assert resp.status_code == 422, resp.text
+    assert "perf" in resp.text.lower() or "event" in resp.text.lower()
+
+
+# --------------------------------------------------------------------------- #
+# Continuous service subscriptions & auto-enrollment (AT-S10 .. AT-S13)
+# --------------------------------------------------------------------------- #
+
+def _subscribe_service(client, service, seed_host):
+    """Create an active service-wide continuous subscription."""
+    h.send_heartbeat(client, hostname=seed_host, service_name=service)
+    resp = h.submit(
+        client, h.start_request(service, target_scope="service", continuous=True)
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_at_s10_new_host_auto_enrolls(client):
+    """AT-S10: a new host under an active subscription gets a start on its first heartbeat."""
+    service = h.unique("s10")
+    seed, newcomer = h.unique("host"), h.unique("host")
+    _subscribe_service(client, service, seed)
+
+    beat = h.send_heartbeat(client, hostname=newcomer, service_name=service)
+    assert beat["profiling_command"] is not None
+    assert beat["profiling_command"]["command_type"] == "start"
+
+
+def test_at_s11_no_subscription_no_enrollment(client):
+    """AT-S11: with no active subscription, a new host gets no command."""
+    service = h.unique("s11")
+    host = h.unique("host")
+    beat = h.send_heartbeat(client, hostname=host, service_name=service)
+    assert beat["profiling_command"] is None
+
+
+def test_at_s12_stop_deactivates_subscription(client):
+    """AT-S12: after a service-wide stop, a new host is not enrolled."""
+    service = h.unique("s12")
+    seed, newcomer = h.unique("host"), h.unique("host")
+    _subscribe_service(client, service, seed)
+
+    resp = h.submit(
+        client, h.stop_request(service, target_scope="service", stop_level="host")
+    )
+    assert resp.status_code == 200, resp.text
+
+    beat = h.send_heartbeat(client, hostname=newcomer, service_name=service)
+    assert beat["profiling_command"] is None or beat["profiling_command"]["command_type"] != "start"
+
+
+def test_at_s13_existing_command_preserved(client):
+    """AT-S13: auto-enroll does not overwrite a host's existing command."""
+    service = h.unique("s13")
+    seed = h.unique("host")
+    _subscribe_service(client, service, seed)
+
+    first = h.send_heartbeat(client, hostname=seed, service_name=service)
+    assert first["profiling_command"] is not None
+    command_id = first["command_id"]
+
+    # Subsequent heartbeats under the active subscription must not replace it.
+    second = h.send_heartbeat(client, hostname=seed, service_name=service)
+    assert second["command_id"] == command_id
+
+
+# --------------------------------------------------------------------------- #
+# Compatibility & failure handling (AT-S14 .. AT-S15)
+# --------------------------------------------------------------------------- #
+
+def test_at_s14_legacy_heartbeat(client):
+    """AT-S14: a heartbeat with no workload fields still yields host status + host commands."""
+    service = h.unique("s14")
+    host = h.unique("host")
+    # No namespace/pod/containers at all.
+    h.send_heartbeat(client, hostname=host, service_name=service)
+
+    status = h.get_workload_status(client, scope="host", service_name=service)
+    rows = h.rows_for(status, service)
+    assert host in {r["hostname"] for r in rows}
+    assert status["tabCounts"]["namespace"] == 0
+    assert status["tabCounts"]["pod"] == 0
+    assert status["tabCounts"]["container"] == 0
+
+    # Host-level command path still works.
+    resp = h.submit(client, h.start_request(service, target_scope="host", target_hosts={host: []}))
+    assert resp.status_code == 200, resp.text
+    beat = h.send_heartbeat(client, hostname=host, service_name=service)
+    assert beat["profiling_command"] is not None
+
+
+def test_at_s15_partial_inventory(client):
+    """AT-S15: heartbeats missing some fields (no pod_name) don't break other scopes."""
+    service = h.unique("s15")
+    host = h.unique("host")
+    # Container has a namespace + processes but no pod_name.
+    h.send_heartbeat(
+        client,
+        hostname=host,
+        service_name=service,
+        namespace="team-x",
+        containers=[h.container("app", [h.process(7)], namespace="team-x")],
+    )
+
+    status = h.get_workload_status(client, scope="host", service_name=service)
+    tabs = status["tabCounts"]
+    assert host in {r["hostname"] for r in h.rows_for(status, service)}
+    assert tabs["namespace"] == 1
+    assert tabs["container"] == 1
+    assert tabs["process"] == 1
+    # No invented pod relationships.
+    assert tabs["pod"] == 0

--- a/src/tests/playwright/.gitignore
+++ b/src/tests/playwright/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+package-lock.json
+test-results/
+playwright-report/
+blob-report/
+.cache/

--- a/src/tests/playwright/Dockerfile
+++ b/src/tests/playwright/Dockerfile
@@ -1,0 +1,13 @@
+# Playwright UI test runner. Uses the official image (browsers + system deps
+# preinstalled) so it works regardless of host libraries, and runs on the
+# compose network to reach the console via the internal nginx service.
+#
+# Image tag MUST match the @playwright/test version in package.json.
+FROM mcr.microsoft.com/playwright:v1.61.1-noble
+
+WORKDIR /work
+COPY package.json package-lock.json* ./
+RUN npm install
+COPY . .
+
+CMD ["npx", "playwright", "test"]

--- a/src/tests/playwright/README.md
+++ b/src/tests/playwright/README.md
@@ -1,0 +1,18 @@
+# Playwright UI acceptance tests
+
+Drives the profiling console through the internal nginx (basic auth +
+self-signed TLS) and asserts the start/stop confirmation flow (dry-run
+validation + submit). The STOP case is the UI regression test for the
+host-level-stop bug.
+
+Runs in the official Playwright browser image on the compose network — don't run
+it against the host (host browser libs may be missing). Use the e2e harness:
+
+```bash
+cd ../../../deploy
+make -f Makefile.e2e e2e-up        # or e2e-up-src (source-built agent)
+make -f Makefile.e2e e2e-ui-test   # builds this runner and executes it in-network
+```
+
+Full harness docs (topology, LocalStack S3/SQS, portability):
+[`deploy/E2E_HARNESS.md`](../../../deploy/E2E_HARNESS.md).

--- a/src/tests/playwright/package.json
+++ b/src/tests/playwright/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "gprofiler-studio-e2e-ui",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Playwright UI acceptance tests for the Performance Studio profiling console",
+  "scripts": {
+    "test": "playwright test",
+    "install-browser": "playwright install chromium"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.61.1"
+  }
+}

--- a/src/tests/playwright/playwright.config.ts
+++ b/src/tests/playwright/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Drives the running console behind nginx (self-signed TLS + basic auth).
+// From host:      E2E_UI_URL=https://localhost:4433 (default)
+// From network:   E2E_UI_URL=https://nginx-load-balancer
+export default defineConfig({
+  testDir: './tests',
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  fullyParallel: false,
+  retries: process.env.CI ? 1 : 0,
+  reporter: 'list',
+  use: {
+    baseURL: process.env.E2E_UI_URL || 'https://localhost:4433',
+    ignoreHTTPSErrors: true,
+    httpCredentials: {
+      username: process.env.E2E_BASIC_AUTH_USER || 'admin',
+      password: process.env.E2E_BASIC_AUTH_PASSWORD || 'admin',
+    },
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+});

--- a/src/tests/playwright/tests/profiling.spec.ts
+++ b/src/tests/playwright/tests/profiling.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect, Page } from '@playwright/test';
+
+// The service the harness agent reports as (see docker-compose.e2e.yml).
+const SERVICE = process.env.E2E_UI_SERVICE || 'e2e-sample-app';
+const BULK_URL = '/api/metrics/profile_request/bulk';
+
+async function openConsoleAndSelectService(page: Page) {
+  await page.goto('/profiling');
+
+  // The DataGrid renders one row per workload; wait for our service to appear.
+  const row = page.getByRole('row', { name: new RegExp(SERVICE) }).first();
+  await expect(row).toBeVisible({ timeout: 30_000 });
+
+  // Select the row via its checkbox (MUI DataGrid checkboxSelection).
+  await row.getByRole('checkbox').check();
+  return row;
+}
+
+async function confirmAndAwaitSubmit(page: Page, action: 'Start' | 'Stop') {
+  // Open the confirmation dialog from the top-panel action button.
+  await page.getByRole('button', { name: new RegExp(`${action} Profiling \\(\\d+\\)`) }).click();
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+
+  // The confirm button is gated on a server-side dry-run validation:
+  //   disabled={dryRunValidation.isValidating || !dryRunValidation.isValid}
+  // So it only enables when the request validates. For a host/service-level
+  // STOP this is exactly the regression that previously failed with
+  // "No PIDs should be provided when request_type is 'stop' ...".
+  const confirm = dialog.getByRole('button', { name: new RegExp(`^${action} Profiling$`) });
+  await expect(confirm).toBeEnabled({ timeout: 15_000 });
+
+  // Submit and assert the real (non dry-run) bulk request succeeds.
+  const [resp] = await Promise.all([
+    page.waitForResponse((r) => {
+      if (!r.url().includes(BULK_URL) || r.request().method() !== 'POST') return false;
+      try {
+        return JSON.parse(r.request().postData() || '{}').dry_run === false;
+      } catch {
+        return false;
+      }
+    }),
+    confirm.click(),
+  ]);
+  expect(resp.status()).toBe(200);
+  return resp;
+}
+
+test.describe('profiling console', () => {
+  test('service/host-level STOP validates and submits (regression AT for the stop bug)', async ({ page }) => {
+    await openConsoleAndSelectService(page);
+    await confirmAndAwaitSubmit(page, 'Stop');
+    // No "No PIDs should be provided" validation error should ever surface.
+    await expect(page.getByText(/No PIDs should be provided/i)).toHaveCount(0);
+  });
+
+  test('service/host-level START validates and submits', async ({ page }) => {
+    await openConsoleAndSelectService(page);
+    await confirmAndAwaitSubmit(page, 'Start');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a local **end-to-end test harness** that runs the full Performance Studio stack together with a real gProfiler agent and a deterministic CPU workload — no AWS account needed (S3 + SQS are emulated via LocalStack).
- Ships two acceptance layers over the workload-level profiling flow:
  - **API suite** (`src/tests/e2e/`, AT-S1..S15) — in-network pytest driving the live stack over HTTP.
  - **UI suite** (`src/tests/playwright/`) — Playwright tests for the console start/stop flow, including regression coverage for the host/service-level stop bug.
- Overlay + Make targets (`deploy/docker-compose.e2e.yml`, `deploy/Makefile.e2e`, `deploy/e2e/agent-glibc.Dockerfile`) wire the sample app, agent, and test runners onto the compose network. Docs in `deploy/E2E_HARNESS.md` (topology, LocalStack S3/SQS, prerequisites, portability).

The agent image defaults to the upstream public `intel/gprofiler:latest`; override `GPROFILER_IMAGE` or build from source via `make -f Makefile.e2e e2e-up-src`. No credentials, TLS keys, or internal infrastructure references are committed.

## Test plan
- [ ] `cd deploy && make -f Makefile.e2e e2e-up-src` brings up studio + sample workload + source-built agent
- [ ] `make -f Makefile.e2e e2e-test` — API acceptance suite (AT-S1..S15) passes against the live stack
- [ ] `make -f Makefile.e2e e2e-ui-test` — Playwright UI suite (start/stop) passes
- [ ] Verify heartbeat -> start -> S3 upload -> SQS -> ClickHouse -> flamegraph pipeline end to end

Made with [Cursor](https://cursor.com)