### PR TITLE
test(k8s): local Kubernetes sandbox for workload-level profiling

### DIFF
--- a/deploy/k8s-sandbox/K8S_SANDBOX.md
+++ b/deploy/k8s-sandbox/K8S_SANDBOX.md
@@ -1,0 +1,208 @@
+# Kubernetes sandbox (real workload/pod/container scoping)
+
+A self-contained, disposable **Kubernetes** environment that runs the full
+Performance Studio stack **plus a real gProfiler agent DaemonSet** and a set of
+tenant workloads, so the workload-level profiling flow can be exercised against a
+**genuine cluster topology**.
+
+> **This page is the operational runbook.** For the architecture, the
+> "what is kind" primer, and the pods-vs-systemd topology breakdown, see
+> [`docs/K8S_SANDBOX.md`](../../docs/K8S_SANDBOX.md).
+
+This is a *separate layer* from the docker-compose harness in
+[`deploy/E2E_HARNESS.md`](../E2E_HARNESS.md) — it does not replace it. Use them
+for different jobs:
+
+| Layer | Orchestrator | Best at | Can't do |
+|-------|--------------|---------|----------|
+| `deploy/Makefile.e2e` (compose) | Docker Compose | fast API + full S3→SQS→indexer→ClickHouse→flamegraph pipeline smoke | no real namespaces/pods/containers (no CRI) |
+| `deploy/k8s-sandbox` (this) | kind / minikube | **real namespace/pod/container/process inventory + scope resolution** | heavier, slower inner loop |
+
+## Why this exists (the one thing compose cannot do)
+
+Workload-level profiling resolves **namespace / pod / container / process**
+selections. The agent builds that inventory in
+`gprofiler/metadata/heartbeat_metadata.py` by asking `granulate_utils`'
+`ContainersClient` to enumerate the node's containers and reading the kubelet
+labels `io.kubernetes.pod.namespace`, `io.kubernetes.pod.name`,
+`io.kubernetes.container.name`.
+
+`ContainersClient` talks to the **container-runtime socket** — CRI at
+`/run/containerd/containerd.sock` (or `/var/run/crio/crio.sock`) and/or Docker —
+**not** the Kubernetes API server. Under docker-compose there is no such socket
+for the agent, so it logs `No container runtime found for heartbeat workload
+inventory` and the pod/container/namespace tabs are exercised only with
+*synthetic* heartbeats. On a real node the socket exists, so the inventory is
+**real**.
+
+### How the DaemonSet reaches the socket
+
+`granulate_utils` resolves the socket path under `HOST_ROOT_PREFIX = /proc/1/root`
+(see `granulate_utils/linux/ns.py`). So the mechanism is:
+
+- **`hostPID: true`** → PID 1 in the pod is the host init, so `/proc/1/root` is
+  the node root filesystem and `/proc/1/root/run/containerd/containerd.sock` is
+  the node's real CRI socket. `hostPID` is also what lets the agent see every
+  node PID to map processes → containers (`get_process_container_id`).
+- **`privileged: true`** → grants access to that socket and lets py-spy `ptrace`
+  the target workloads.
+
+No bind-mount of the socket is required; the two flags above are the whole trick.
+See [`manifests/50-agent-daemonset.yaml`](manifests/50-agent-daemonset.yaml).
+
+> **Use the source-built agent.** The container-inventory heartbeat is a fork
+> feature, so the public `intel/gprofiler:latest` image will **not** populate the
+> pod/container tabs. `k8s-agent-build` builds it from the sibling `../../gprofiler`
+> checkout (reusing `deploy/e2e/agent-glibc.Dockerfile`).
+
+## Architecture
+
+```
+ kind / minikube node (containerd)
+ ┌──────────────────────────────────────────────────────────────────────┐
+ │ ns team-a: checkout(x2), web     ns team-b: payments, search(app+car)  │
+ │        ▲ enumerated via CRI (/proc/1/root/run/containerd/...)          │
+ │ gprofiler-agent DaemonSet ──heartbeat/commands──► webapp ──► postgres  │
+ │  (hostPID, privileged)                 │                               │
+ │                                        └── upload ──► S3 (LocalStack)  │
+ │                                                          ▼            │
+ │                                              SQS ──► ch-indexer ──► ClickHouse
+ │                                                          ▼            │
+ │                                              nginx NodePort :30443 (UI) │
+ └──────────────────────────────────────────────────────────────────────┘
+```
+
+Everything is in the `perf-studio` namespace except the tenant workloads
+(`team-a`, `team-b`). Only the optional nginx edge is published (NodePort 30443);
+the agent and the in-cluster test Job reach `http://webapp` directly.
+
+## Prerequisites
+
+- **Docker**, plus **`kind`** (recommended) or **`minikube`**, and **`kubectl`**.
+- **`python3`** on your host (used to parse the minted profiler token).
+- The **agent repo** checked out at `../../../gprofiler` (sibling of the studio
+  repo) for `k8s-agent-build`.
+- TLS certs + `.htpasswd` in `deploy/` (same one-time step as the compose
+  harness — see [`deploy/E2E_HARNESS.md`](../E2E_HARNESS.md#prerequisites)).
+
+## Quick start
+
+```bash
+cd deploy/k8s-sandbox
+
+# One-shot: create cluster, build+load images, deploy stack+workloads+agent, mint token.
+make -f Makefile.k8s k8s-all
+
+# Give the agent ~30-60s to enumerate CRI, then inspect the live inventory.
+make -f Makefile.k8s k8s-status
+
+# Run the real-topology acceptance suite (AT-K1..K5).
+make -f Makefile.k8s k8s-test
+
+# Drive the control plane against the real agent.
+make -f Makefile.k8s k8s-start
+make -f Makefile.k8s k8s-stop
+
+# Open the console (basic auth admin/admin).
+make -f Makefile.k8s k8s-url
+
+# Tear the whole sandbox down.
+make -f Makefile.k8s k8s-down-all
+```
+
+Use `CLUSTER=minikube` on any target to use minikube instead of kind:
+
+```bash
+make -f Makefile.k8s k8s-all CLUSTER=minikube
+```
+
+`make -f Makefile.k8s help` lists all targets.
+
+## What the acceptance suite proves (AT-K1..K5)
+
+[`tests/test_k8s_inventory.py`](tests/test_k8s_inventory.py), run in-cluster as a
+Job against the live `webapp`:
+
+- **AT-K1** — the real agent DaemonSet registers as a host under service
+  `k8s-sandbox`.
+- **AT-K2** — tenant **namespaces** (`team-a`, `team-b`) appear in the namespace
+  scope (discovered from CRI, not fabricated).
+- **AT-K3** — **pods** for each workload (`checkout`, `web`, `payments`,
+  `search`) appear in the pod scope.
+- **AT-K4** — **containers** appear, including *both* containers of the
+  2-container `search` pod (`search-app`, `search-sidecar`).
+- **AT-K5** — a host-scope start/stop resolves the **real** agent host (from live
+  inventory) and is accepted — command creation against an actual agent.
+
+The suite reuses the compose suite's HTTP harness (`src/tests/e2e/harness.py`) so
+the request/response contract lives in one place, and matches on serialized
+inventory (not hard-coded per-scope key casing) so it stays robust as the node
+also contains system/studio containers.
+
+## Files
+
+| Path | Purpose |
+|------|---------|
+| `Makefile.k8s` | cluster/build/load/deploy/token/test/start/stop/down targets |
+| `kind-config.yaml` | single-node kind cluster; publishes nginx NodePort 30443 |
+| `manifests/00-namespaces.yaml` | `perf-studio`, `team-a`, `team-b` |
+| `manifests/01-config.yaml` | shared `studio-config` ConfigMap + `studio-secrets` |
+| `manifests/10-datastores.yaml` | Postgres + ClickHouse (schema via init ConfigMaps) |
+| `manifests/12-localstack.yaml` | S3 + SQS emulator (init from ConfigMap) |
+| `manifests/13-ch-rest-service.yaml` | ClickHouse REST facade (TLS from Secret) |
+| `manifests/20-webapp.yaml` | FastAPI backend + UI (`http://webapp`) |
+| `manifests/21-ch-indexer.yaml` | SQS→ClickHouse indexer |
+| `manifests/22-logs-backend.yaml` | agent-logs + periodic-tasks (shared `/logs`) |
+| `manifests/30-nginx.yaml` | optional TLS/basic-auth edge (NodePort 30443) |
+| `manifests/40-workloads.yaml` | tenant workloads the agent enumerates |
+| `manifests/50-agent-daemonset.yaml` | **the real agent (hostPID + privileged)** |
+| `tests/` | in-cluster acceptance Job + real-topology tests |
+
+## Notes & caveats
+
+- **kind vs minikube.** kind is the default and recommended for CI (lighter,
+  containerd-native, faster boot). minikube is supported for local use via
+  `CLUSTER=minikube` (start it with `--container-runtime=containerd`).
+- **Inner loop.** Unlike compose (which builds straight from `../src`), a cluster
+  requires images to be *loaded* in (`kind load` / `minikube image load`) after
+  each rebuild — re-run `k8s-images && k8s-load` (or `k8s-agent-build && k8s-load`)
+  when you change code.
+- **Disposable.** The cluster is hermetic: LocalStack fakes AWS and nothing
+  leaves the node. `k8s-down-all` deletes the cluster and leaves no residue.
+- **The agent enumerates the whole node**, so inventory also contains
+  `kube-system`/studio containers — expected. The tests assert on the specific
+  tenant entities rather than exact totals.
+- **Low ports as non-root.** The webapp and agents-logs-backend images run as a
+  non-root user and bind port 80. Docker permits this via its default
+  `net.ipv4.ip_unprivileged_port_start=0`; Kubernetes does not, so those pods set
+  that (safe) sysctl in their `securityContext`. If your kubelet restricts safe
+  sysctls, allowlist `net.ipv4.ip_unprivileged_port_start` (or run those two as
+  root).
+
+## Verified
+
+Brought up on a single-node **kind v1.30** cluster (containerd 1.7) and confirmed
+end to end:
+
+- The agent DaemonSet connects and heartbeats with **no** `No container runtime
+  found` error (contrast the compose harness), i.e. it reached the node's CRI
+  socket via `/proc/1/root` with `hostPID` + `privileged`.
+- `workload_status` reported real topology — `tabCounts` `{service:1, host:1,
+  namespace:5, pod:23, container:25, process:93}` — including the tenant
+  namespaces `team-a`/`team-b` and the 2-container `search` pod resolved as
+  distinct `search-app` + `search-sidecar` containers.
+- The full acceptance suite passed: `AT-K1..K5` (5 passed).
+- **Full artifact pipeline closed in-cluster**: a host-scope start made the agent
+  profile the real workloads and upload; the webapp wrote the collapsed stacks to
+  S3 (`products/k8s-sandbox/stacks/...gz`) and enqueued SQS; the indexer consumed
+  it, inserted 27 rows into `flamedb.samples`, and wrote the rendered
+  `..._adhoc_flamegraph.html` back to S3 — all against LocalStack, no real AWS.
+
+Two k8s-specific fixes came out of that run (both committed):
+
+- **Non-root low-port bind** (webapp, agents-logs-backend) — added the
+  `net.ipv4.ip_unprivileged_port_start=0` sysctl (above).
+- **Indexer startup ordering** — compose gated it on `localstack: service_healthy`;
+  k8s has no `depends_on` and the indexer resolves the SQS URL once without
+  retry, so it can boot before LocalStack and never consume. Added an
+  init-container that waits for LocalStack's SQS to report running.

--- a/deploy/k8s-sandbox/Makefile.k8s
+++ b/deploy/k8s-sandbox/Makefile.k8s
@@ -1,0 +1,232 @@
+# Kubernetes sandbox for Performance Studio + a REAL gProfiler agent DaemonSet.
+#
+# This is the k8s-native counterpart of deploy/Makefile.e2e. Its reason to exist:
+# a DaemonSet on a real node reads the node's CRI socket and enumerates genuine
+# pods/containers, so it proves the workload/pod/container scope resolution that
+# docker-compose cannot (compose has no container runtime -> empty inventory).
+#
+# One-shot:
+#   make -f Makefile.k8s k8s-all          # cluster + build + load + deploy + token
+#   make -f Makefile.k8s k8s-test         # run AT-K1..K5 real-topology acceptance
+#   make -f Makefile.k8s k8s-down-all     # delete the whole cluster
+#
+# Granular targets are listed in `make -f Makefile.k8s help`.
+
+SHELL := /bin/bash
+
+# kind (default, recommended for CI: lighter, containerd-native) or minikube.
+CLUSTER      ?= kind
+CLUSTER_NAME ?= gprofiler-sandbox
+NS           ?= perf-studio
+
+# Source-built agent (the container-inventory heartbeat is a fork feature, so the
+# public image would leave pod/container tabs empty). Mirrors Makefile.e2e.
+AGENT_REPO   ?= ../../../gprofiler
+AGENT_ARCH   ?= x86_64
+AGENT_IMAGE  ?= gprofiler-e2e-agent:src
+
+VITE_DOCUMENTATION_URL ?= http://custom.gprofiler.doc.domain/
+
+# Locally-built studio images (referenced by the manifests with the same tags).
+STUDIO_IMAGES := \
+  gprofiler-ps/webapp:sandbox \
+  gprofiler-ps/ch-rest-service:sandbox \
+  gprofiler-ps/ch-indexer:sandbox \
+  gprofiler-ps/agents-logs-backend:sandbox \
+  gprofiler-ps/periodic-tasks:sandbox
+TESTS_IMAGE := gprofiler-ps/k8s-tests:sandbox
+
+KUBECTL := kubectl -n $(NS)
+
+.PHONY: help k8s-all k8s-cluster k8s-images k8s-agent-build k8s-load k8s-config \
+        k8s-deploy k8s-token k8s-up k8s-status k8s-test k8s-start k8s-stop \
+        k8s-flamegraph k8s-logs k8s-ui k8s-url k8s-down k8s-down-all
+
+help:
+	@grep -E '^## ' $(MAKEFILE_LIST) | sed 's/^## //'
+
+## k8s-all         : cluster + images + agent + load + deploy + token (one-shot)
+k8s-all: k8s-cluster k8s-images k8s-agent-build k8s-load k8s-up
+	@echo ">> sandbox ready. Try: make -f Makefile.k8s k8s-status"
+
+## k8s-cluster     : create the local cluster (CLUSTER=kind|minikube)
+k8s-cluster:
+ifeq ($(CLUSTER),kind)
+	@kind get clusters 2>/dev/null | grep -qx $(CLUSTER_NAME) \
+	  && echo ">> kind cluster $(CLUSTER_NAME) already exists" \
+	  || kind create cluster --name $(CLUSTER_NAME) --config kind-config.yaml
+else ifeq ($(CLUSTER),minikube)
+	@minikube status -p $(CLUSTER_NAME) >/dev/null 2>&1 \
+	  && echo ">> minikube profile $(CLUSTER_NAME) already running" \
+	  || minikube start -p $(CLUSTER_NAME) --container-runtime=containerd --ports=30443:30443
+else
+	@echo "Unsupported CLUSTER=$(CLUSTER) (use kind or minikube)"; exit 1
+endif
+
+## k8s-images      : build the studio + test images from source
+k8s-images:
+	@echo ">> building studio images from source"
+	docker build -t gprofiler-ps/webapp:sandbox \
+	  -f ../../src/gprofiler/Dockerfile \
+	  --build-arg VITE_DOCUMENTATION_URL=$(VITE_DOCUMENTATION_URL) ../../src
+	docker build -t gprofiler-ps/ch-rest-service:sandbox ../../src/gprofiler_flamedb_rest
+	docker build -t gprofiler-ps/ch-indexer:sandbox ../../src/gprofiler_indexer
+	docker build -t gprofiler-ps/agents-logs-backend:sandbox \
+	  -f ../../src/gprofiler_logging/Dockerfile ../../src
+	docker build -t gprofiler-ps/periodic-tasks:sandbox ../periodic_tasks
+	@echo ">> building k8s acceptance test image (context = studio root)"
+	docker build -f tests/Dockerfile -t $(TESTS_IMAGE) ../..
+
+## k8s-agent-build  : build the agent FROM SOURCE (fast, glibc-wrapped)
+k8s-agent-build:
+	@echo ">> building agent executable from source (--fast, no staticx)"
+	cd $(AGENT_REPO) && scripts/build_$(AGENT_ARCH)_executable.sh --fast
+	@echo ">> wrapping exe in glibc base -> $(AGENT_IMAGE)"
+	docker build -f ../e2e/agent-glibc.Dockerfile --build-arg ARCH=$(AGENT_ARCH) -t $(AGENT_IMAGE) $(AGENT_REPO)
+
+## k8s-load        : load all locally-built images into the cluster
+k8s-load:
+	@for img in $(STUDIO_IMAGES) $(TESTS_IMAGE) $(AGENT_IMAGE); do \
+	  echo ">> loading $$img"; \
+	  if [ "$(CLUSTER)" = "kind" ]; then \
+	    kind load docker-image $$img --name $(CLUSTER_NAME); \
+	  else \
+	    minikube image load $$img -p $(CLUSTER_NAME); \
+	  fi; \
+	done
+
+## k8s-config      : create ConfigMaps/Secrets from the existing deploy/ files
+k8s-config:
+	$(KUBECTL) apply -f manifests/00-namespaces.yaml
+	$(KUBECTL) apply -f manifests/01-config.yaml
+	@echo ">> schema + init ConfigMaps (single source of truth with compose)"
+	$(KUBECTL) create configmap pg-initdb \
+	  --from-file=create_scheme.sql=../../scripts/setup/postgres/gprofiler_recreate.sql \
+	  --dry-run=client -o yaml | $(KUBECTL) apply -f -
+	$(KUBECTL) create configmap ch-initdb \
+	  --from-file=create_schema.sql=../../src/gprofiler_indexer/sql/create_ch_schema.sql \
+	  --dry-run=client -o yaml | $(KUBECTL) apply -f -
+	$(KUBECTL) create configmap localstack-init \
+	  --from-file=../localstack_init \
+	  --dry-run=client -o yaml | $(KUBECTL) apply -f -
+	@echo ">> TLS + nginx edge inputs"
+	$(KUBECTL) create secret generic ch-rest-tls \
+	  --from-file=ch_rest_cert.pem=../tls/ch_rest_cert.pem \
+	  --from-file=ch_rest_key.pem=../tls/ch_rest_key.pem \
+	  --dry-run=client -o yaml | $(KUBECTL) apply -f -
+	$(KUBECTL) create configmap nginx-conf \
+	  --from-file=nginx.conf=../https_nginx.conf \
+	  --dry-run=client -o yaml | $(KUBECTL) apply -f -
+	$(KUBECTL) create secret generic nginx-tls \
+	  --from-file=cert.pem=../tls/cert.pem --from-file=key.pem=../tls/key.pem \
+	  --dry-run=client -o yaml | $(KUBECTL) apply -f -
+	$(KUBECTL) create secret generic nginx-htpasswd \
+	  --from-file=.htpasswd=../.htpasswd \
+	  --dry-run=client -o yaml | $(KUBECTL) apply -f -
+	@echo ">> placeholder agent token (replaced by k8s-token)"
+	$(KUBECTL) create secret generic gprofiler-agent-token \
+	  --from-literal=token=bootstrap \
+	  --dry-run=client -o yaml | $(KUBECTL) apply -f -
+
+## k8s-deploy      : apply all manifests (core stack + workloads + agent)
+k8s-deploy:
+	$(KUBECTL) apply -f manifests/
+	@echo ">> waiting for the webapp to become ready..."
+	$(KUBECTL) rollout status deploy/webapp --timeout=300s
+
+## k8s-token       : mint a real profiler token and restart the agent with it
+k8s-token:
+	@echo ">> minting profiler token from the running studio"
+	@tok=$$($(KUBECTL) run tokfetch-$$RANDOM --image=curlimages/curl:8.7.1 \
+	  --restart=Never -i --rm --quiet --command -- \
+	  curl -s http://webapp/api/api_key \
+	  | python3 -c "import sys,json;print(json.load(sys.stdin)['apiKey'])"); \
+	 echo ">> token: $$tok"; \
+	 $(KUBECTL) create secret generic gprofiler-agent-token \
+	   --from-literal=token=$$tok --dry-run=client -o yaml | $(KUBECTL) apply -f -
+	$(KUBECTL) rollout restart daemonset/gprofiler-agent
+	$(KUBECTL) rollout status daemonset/gprofiler-agent --timeout=180s
+
+## k8s-up          : config + deploy + token (assumes cluster up & images loaded)
+k8s-up: k8s-config k8s-deploy k8s-token
+	@echo ">> up. Give the agent ~30-60s to enumerate CRI, then: make -f Makefile.k8s k8s-status"
+
+## k8s-status      : show the live workload inventory (all scopes)
+k8s-status:
+	@echo "== pods ==" && $(KUBECTL) get pods -o wide
+	@echo "== agent DaemonSet ==" && $(KUBECTL) get ds gprofiler-agent
+	@echo "== workload_status (host scope) ==" ; \
+	 $(KUBECTL) run wsq-$$RANDOM --image=curlimages/curl:8.7.1 --restart=Never -i --rm --quiet --command -- \
+	   curl -s "http://webapp/api/metrics/profiling/workload_status?scope=host" | python3 -m json.tool || true
+
+## k8s-test        : run the real-topology acceptance suite (AT-K1..K5) as a Job
+k8s-test:
+	$(KUBECTL) delete job k8s-acceptance --ignore-not-found
+	$(KUBECTL) apply -f tests/job-api.yaml
+	@echo ">> waiting for the acceptance Job..."
+	@$(KUBECTL) wait --for=condition=complete job/k8s-acceptance --timeout=420s & \
+	 comp=$$!; \
+	 $(KUBECTL) wait --for=condition=failed job/k8s-acceptance --timeout=420s & \
+	 fail=$$!; \
+	 wait -n $$comp $$fail; \
+	 $(KUBECTL) logs job/k8s-acceptance
+
+## k8s-start       : host-scope START for the real agent (SERVICE overridable)
+SERVICE ?= k8s-sandbox
+# Host discovery + JSON parsing run on the HOST (python3), not in the curl pod
+# (the curl image has no python3); only the raw HTTP calls run in-cluster.
+define resolve_host
+$$(kubectl -n $(NS) run hs-$$RANDOM --image=curlimages/curl:8.7.1 --restart=Never -i --rm --quiet --command -- \
+  curl -s "http://webapp/api/metrics/profiling/host_status?service_name=$(SERVICE)" \
+  | python3 -c "import sys,json;print(json.load(sys.stdin)['hosts'][0]['hostname'])")
+endef
+
+k8s-start:
+	@host=$(call resolve_host); echo ">> start on host=$$host"; \
+	 req=$$(python3 -c "import json;print(json.dumps({'service_name':'$(SERVICE)','request_type':'start','continuous':False,'duration':30,'frequency':11,'profiling_mode':'cpu','target_scope':'host','target_hosts':{'$$host':[]},'target_entities':[{'service_name':'$(SERVICE)','hostname':'$$host'}],'additional_args':{}}))"); \
+	 $(KUBECTL) run rq-$$RANDOM --image=curlimages/curl:8.7.1 --restart=Never -i --rm --quiet --command -- \
+	   curl -s -X POST "http://webapp/api/metrics/profile_request" -H "Content-Type: application/json" -d "$$req"
+
+## k8s-stop        : host-scope STOP for the real agent
+k8s-stop:
+	@host=$(call resolve_host); echo ">> stop on host=$$host"; \
+	 req=$$(python3 -c "import json;print(json.dumps({'service_name':'$(SERVICE)','request_type':'stop','continuous':False,'duration':30,'frequency':11,'profiling_mode':'cpu','target_scope':'host','stop_level':'host','target_hosts':{'$$host':[]},'target_entities':[{'service_name':'$(SERVICE)','hostname':'$$host'}],'additional_args':{}}))"); \
+	 $(KUBECTL) run rq-$$RANDOM --image=curlimages/curl:8.7.1 --restart=Never -i --rm --quiet --command -- \
+	   curl -s -X POST "http://webapp/api/metrics/profile_request" -H "Content-Type: application/json" -d "$$req"
+
+## k8s-flamegraph  : list flamegraph artifacts produced in (Local)S3
+# NOTE: the amazon/aws-cli image ENTRYPOINT is already `aws`, so pass args
+# directly after `--` (no `--command`, which would override the entrypoint).
+k8s-flamegraph:
+	@$(KUBECTL) run s3ls-$$RANDOM --image=amazon/aws-cli:2.15.0 --restart=Never -i --rm --quiet \
+	  --env=AWS_ACCESS_KEY_ID=test --env=AWS_SECRET_ACCESS_KEY=test --env=AWS_DEFAULT_REGION=us-east-1 \
+	  -- --endpoint-url http://localstack:4566 s3 ls s3://performance-studio-bucket/ --recursive || true
+
+## k8s-logs        : follow the agent DaemonSet logs
+k8s-logs:
+	$(KUBECTL) logs -f ds/gprofiler-agent
+
+## k8s-ui          : print how to reach the console (via nginx NodePort)
+k8s-ui: k8s-url
+
+## k8s-url         : print the console URL (basic auth admin/admin)
+k8s-url:
+	@echo "Console (basic auth from deploy/.htpasswd):"
+ifeq ($(CLUSTER),kind)
+	@echo "  https://localhost:30443   (kind extraPortMapping)"
+else
+	@echo "  https://$$(minikube ip -p $(CLUSTER_NAME)):30443"
+endif
+
+## k8s-down        : remove workloads + agent (studio stack stays up)
+k8s-down:
+	$(KUBECTL) delete -f manifests/40-workloads.yaml --ignore-not-found
+	$(KUBECTL) delete -f manifests/50-agent-daemonset.yaml --ignore-not-found
+
+## k8s-down-all    : delete the entire cluster (destructive)
+k8s-down-all:
+ifeq ($(CLUSTER),kind)
+	kind delete cluster --name $(CLUSTER_NAME)
+else
+	minikube delete -p $(CLUSTER_NAME)
+endif

--- a/deploy/k8s-sandbox/kind-config.yaml
+++ b/deploy/k8s-sandbox/kind-config.yaml
@@ -1,0 +1,15 @@
+# Single-node kind cluster for the sandbox. kind nodes run containerd, whose CRI
+# socket at /run/containerd/containerd.sock is exactly what the agent DaemonSet
+# reads (via /proc/1/root with hostPID) to build workload inventory.
+#
+# extraPortMappings publishes the nginx NodePort (30443) to the host so you can
+# open the console at https://localhost:30443 without kubectl port-forward.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: gprofiler-sandbox
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      - containerPort: 30443
+        hostPort: 30443
+        protocol: TCP

--- a/deploy/k8s-sandbox/manifests/00-namespaces.yaml
+++ b/deploy/k8s-sandbox/manifests/00-namespaces.yaml
@@ -1,0 +1,30 @@
+# Namespaces for the k8s sandbox.
+#   perf-studio : the Performance Studio control plane + in-cluster test Jobs
+#   team-a / team-b : realistic tenant namespaces holding the workloads the
+#                     gProfiler agent DaemonSet enumerates over CRI. Having more
+#                     than one namespace is the whole point: it proves the
+#                     namespace/pod/container scope resolution against a real
+#                     cluster topology (which docker-compose cannot produce).
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: perf-studio
+  labels:
+    app.kubernetes.io/part-of: gprofiler-performance-studio
+    gprofiler.sandbox/role: control-plane
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: team-a
+  labels:
+    app.kubernetes.io/part-of: gprofiler-performance-studio
+    gprofiler.sandbox/role: workload
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: team-b
+  labels:
+    app.kubernetes.io/part-of: gprofiler-performance-studio
+    gprofiler.sandbox/role: workload

--- a/deploy/k8s-sandbox/manifests/01-config.yaml
+++ b/deploy/k8s-sandbox/manifests/01-config.yaml
@@ -1,0 +1,49 @@
+# Shared, non-secret configuration for the studio control plane.
+# Mirrors deploy/.env, but with Kubernetes service DNS names instead of the
+# docker-compose service names (k8s Service names cannot contain underscores,
+# so db_postgres -> postgres and db_clickhouse -> clickhouse). Each app already
+# takes its dependency hosts via env, so only these values change.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: studio-config
+  namespace: perf-studio
+data:
+  AWS_REGION: us-east-1
+  AWS_DEFAULT_REGION: us-east-1
+  # LocalStack gateway (S3 + SQS emulator) reachable in-cluster by Service name.
+  AWS_ENDPOINT_URL: http://localstack:4566
+  S3_ENDPOINT_URL: http://localstack:4566
+  SQS_ENDPOINT_URL: http://localstack:4566
+  BUCKET_NAME: performance-studio-bucket
+  # The indexer takes a bare queue name; the webapp takes a full URL. Path-style
+  # LocalStack URL works cross-pod (the localhost.localstack.cloud magic DNS the
+  # compose .env used only resolves on the host).
+  SQS_INDEXER_QUEUE_URL: performance-studio-queue
+  SQS_WEBAPP_QUEUE_URL: http://localstack:4566/000000000000/performance-studio-queue
+  POSTGRES_HOST: postgres
+  POSTGRES_PORT: "5432"
+  POSTGRES_DB: performance_studio
+  POSTGRES_USER: performance_studio
+  CLICKHOUSE_HOST: clickhouse
+  REST_USERNAME: user
+  COMMON_LOGS_DIR: /logs
+  # No external metrics sink in the sandbox (compose pointed at host.docker.internal).
+  METRICS_ENABLED: "false"
+  INDEXER_METRICS_ENABLED: "false"
+  MAX_SIMULTANEOUS_PROFILING_HOSTS: "100"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: studio-secrets
+  namespace: perf-studio
+type: Opaque
+stringData:
+  POSTGRES_PASSWORD: performance_studio_password
+  CLICKHOUSE_USER: dbuser
+  CLICKHOUSE_PASSWORD: simplePassword
+  REST_PASSWORD: pass
+  # Dummy credentials; all AWS traffic is served by LocalStack.
+  AWS_ACCESS_KEY_ID: test
+  AWS_SECRET_ACCESS_KEY: test

--- a/deploy/k8s-sandbox/manifests/10-datastores.yaml
+++ b/deploy/k8s-sandbox/manifests/10-datastores.yaml
@@ -1,0 +1,117 @@
+# Postgres (heartbeat inventory, profiling requests/commands) and ClickHouse
+# (flamedb sample/metric storage). Schemas are loaded from init ConfigMaps that
+# the Makefile creates from the same SQL files docker-compose mounts, so there is
+# a single source of truth for the schema.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: perf-studio
+  labels: { app: postgres }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: postgres }
+  template:
+    metadata:
+      labels: { app: postgres }
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15.1
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POSTGRES_USER
+              valueFrom: { configMapKeyRef: { name: studio-config, key: POSTGRES_USER } }
+            - name: POSTGRES_DB
+              valueFrom: { configMapKeyRef: { name: studio-config, key: POSTGRES_DB } }
+            - name: POSTGRES_PASSWORD
+              valueFrom: { secretKeyRef: { name: studio-secrets, key: POSTGRES_PASSWORD } }
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - name: initdb
+              mountPath: /docker-entrypoint-initdb.d
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            exec:
+              command: ["sh", "-c", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+            initialDelaySeconds: 10
+            periodSeconds: 5
+      volumes:
+        - name: initdb
+          configMap:
+            name: pg-initdb
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: perf-studio
+spec:
+  selector: { app: postgres }
+  ports:
+    - port: 5432
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: clickhouse
+  namespace: perf-studio
+  labels: { app: clickhouse }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: clickhouse }
+  template:
+    metadata:
+      labels: { app: clickhouse }
+    spec:
+      containers:
+        - name: clickhouse
+          image: clickhouse/clickhouse-server:22.8
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: CLICKHOUSE_USER
+              valueFrom: { secretKeyRef: { name: studio-secrets, key: CLICKHOUSE_USER } }
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom: { secretKeyRef: { name: studio-secrets, key: CLICKHOUSE_PASSWORD } }
+          ports:
+            - containerPort: 8123
+            - containerPort: 9000
+          volumeMounts:
+            - name: initdb
+              mountPath: /docker-entrypoint-initdb.d
+            - name: data
+              mountPath: /var/lib/clickhouse
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: 8123
+            initialDelaySeconds: 15
+            periodSeconds: 10
+      volumes:
+        - name: initdb
+          configMap:
+            name: ch-initdb
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clickhouse
+  namespace: perf-studio
+spec:
+  selector: { app: clickhouse }
+  ports:
+    - name: http
+      port: 8123
+      targetPort: 8123
+    - name: native
+      port: 9000
+      targetPort: 9000

--- a/deploy/k8s-sandbox/manifests/12-localstack.yaml
+++ b/deploy/k8s-sandbox/manifests/12-localstack.yaml
@@ -1,0 +1,63 @@
+# LocalStack emulates S3 + SQS in-process so nothing touches real AWS. On startup
+# it runs every script in /etc/localstack/init/ready.d (mounted from a ConfigMap
+# the Makefile builds from deploy/localstack_init/) to create the bucket + queue
+# and wire S3 -> SQS event notifications, exactly like the compose harness.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: localstack
+  namespace: perf-studio
+  labels: { app: localstack }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: localstack }
+  template:
+    metadata:
+      labels: { app: localstack }
+    spec:
+      containers:
+        - name: localstack
+          image: localstack/localstack:3.0
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: SERVICES
+              value: s3,sqs
+            - name: DEBUG
+              value: "1"
+            - name: AWS_DEFAULT_REGION
+              value: us-east-1
+            - name: AWS_ACCESS_KEY_ID
+              value: test
+            - name: AWS_SECRET_ACCESS_KEY
+              value: test
+          ports:
+            - containerPort: 4566
+          volumeMounts:
+            - name: init
+              mountPath: /etc/localstack/init/ready.d
+          readinessProbe:
+            exec:
+              command:
+                - bash
+                - -c
+                - "curl -s http://localhost:4566/_localstack/health | grep -q '\"s3\": \"running\"' && curl -s http://localhost:4566/_localstack/health | grep -q '\"sqs\": \"running\"'"
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 12
+      volumes:
+        - name: init
+          configMap:
+            name: localstack-init
+            defaultMode: 0755
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: localstack
+  namespace: perf-studio
+spec:
+  selector: { app: localstack }
+  ports:
+    - port: 4566
+      targetPort: 4566

--- a/deploy/k8s-sandbox/manifests/13-ch-rest-service.yaml
+++ b/deploy/k8s-sandbox/manifests/13-ch-rest-service.yaml
@@ -1,0 +1,72 @@
+# ClickHouse REST facade the webapp queries for flamegraph data. Serves HTTPS on
+# 4433 with a self-signed cert (mounted from the ch-rest-tls Secret the Makefile
+# creates from deploy/tls/); the webapp trusts it via REST_VERIFY_TLS=FALSE.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ch-rest-service
+  namespace: perf-studio
+  labels: { app: ch-rest-service }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: ch-rest-service }
+  template:
+    metadata:
+      labels: { app: ch-rest-service }
+    spec:
+      securityContext:
+        runAsUser: 888
+        runAsGroup: 888
+        fsGroup: 888
+      containers:
+        - name: ch-rest-service
+          image: gprofiler-ps/ch-rest-service:sandbox
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: CLICKHOUSE_HOST
+              valueFrom: { configMapKeyRef: { name: studio-config, key: CLICKHOUSE_HOST } }
+            - name: CLICKHOUSE_USER
+              valueFrom: { secretKeyRef: { name: studio-secrets, key: CLICKHOUSE_USER } }
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom: { secretKeyRef: { name: studio-secrets, key: CLICKHOUSE_PASSWORD } }
+            - name: REST_PASSWORD
+              valueFrom: { secretKeyRef: { name: studio-secrets, key: REST_PASSWORD } }
+            # $(VAR) expands against env vars declared earlier in this list.
+            - name: CLICKHOUSE_ADDR
+              value: "$(CLICKHOUSE_HOST):9000?username=$(CLICKHOUSE_USER)&password=$(CLICKHOUSE_PASSWORD)"
+            - name: CLICKHOUSE_STACKS_TABLE
+              value: flamedb.samples
+            - name: CLICKHOUSE_METRICS_TABLE
+              value: flamedb.metrics
+            - name: BASIC_AUTH_CREDENTIALS
+              value: "user:$(REST_PASSWORD)"
+            - name: CERT_FILE_PATH
+              value: /tls/ch_rest_cert.pem
+            - name: KEY_FILE_PATH
+              value: /tls/ch_rest_key.pem
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom: { secretKeyRef: { name: studio-secrets, key: AWS_ACCESS_KEY_ID } }
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom: { secretKeyRef: { name: studio-secrets, key: AWS_SECRET_ACCESS_KEY } }
+          ports:
+            - containerPort: 4433
+          volumeMounts:
+            - name: tls
+              mountPath: /tls
+              readOnly: true
+      volumes:
+        - name: tls
+          secret:
+            secretName: ch-rest-tls
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ch-rest-service
+  namespace: perf-studio
+spec:
+  selector: { app: ch-rest-service }
+  ports:
+    - port: 4433
+      targetPort: 4433

--- a/deploy/k8s-sandbox/manifests/20-webapp.yaml
+++ b/deploy/k8s-sandbox/manifests/20-webapp.yaml
@@ -1,0 +1,86 @@
+# FastAPI backend + built UI: heartbeat ingest, profile upload, workload status
+# and profiling request APIs. Serves plain HTTP on :80 internally (TLS is left to
+# the optional nginx edge), so the agent and in-cluster tests reach it directly at
+# http://webapp without going through basic auth.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: webapp
+  namespace: perf-studio
+  labels: { app: webapp }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: webapp }
+  template:
+    metadata:
+      labels: { app: webapp }
+    spec:
+      # The webapp image runs as non_root (uid 888) and binds port 80. Docker
+      # allows low-port binds by non-root via its default
+      # net.ipv4.ip_unprivileged_port_start=0; Kubernetes does not, so set the
+      # (safe) sysctl explicitly to reproduce that behavior.
+      securityContext:
+        sysctls:
+          - name: net.ipv4.ip_unprivileged_port_start
+            value: "0"
+      containers:
+        - name: webapp
+          image: gprofiler-ps/webapp:sandbox
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - configMapRef: { name: studio-config }
+          env:
+            - name: QUERY_API_BASE_URL
+              value: https://ch-rest-service:4433
+            - name: REST_VERIFY_TLS
+              value: "FALSE"
+            - name: REST_PASSWORD
+              valueFrom: { secretKeyRef: { name: studio-secrets, key: REST_PASSWORD } }
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom: { secretKeyRef: { name: studio-secrets, key: AWS_ACCESS_KEY_ID } }
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom: { secretKeyRef: { name: studio-secrets, key: AWS_SECRET_ACCESS_KEY } }
+            # webapp reads Postgres via GPROFILER_POSTGRES_* (not the bare names).
+            - name: GPROFILER_POSTGRES_HOST
+              valueFrom: { configMapKeyRef: { name: studio-config, key: POSTGRES_HOST } }
+            - name: GPROFILER_POSTGRES_PORT
+              valueFrom: { configMapKeyRef: { name: studio-config, key: POSTGRES_PORT } }
+            - name: GPROFILER_POSTGRES_DB_NAME
+              valueFrom: { configMapKeyRef: { name: studio-config, key: POSTGRES_DB } }
+            - name: GPROFILER_POSTGRES_USERNAME
+              valueFrom: { configMapKeyRef: { name: studio-config, key: POSTGRES_USER } }
+            - name: GPROFILER_POSTGRES_PASSWORD
+              valueFrom: { secretKeyRef: { name: studio-secrets, key: POSTGRES_PASSWORD } }
+            - name: APP_LOG_LEVEL
+              value: INFO
+            - name: APP_LOG_FILE_PATH
+              value: webapp.log
+            - name: AWS_METADATA_SERVICE_NUM_ATTEMPTS
+              value: "100"
+            # TLS off internally: no cert paths -> webapp serves plain HTTP on :80.
+            - name: GPROFILER_TLS_CERT_PATH
+              value: ""
+            - name: GPROFILER_TLS_KEY_PATH
+              value: ""
+            - name: GPROFILER_TLS_CA_PATH
+              value: ""
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            tcpSocket:
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: webapp
+  namespace: perf-studio
+spec:
+  selector: { app: webapp }
+  ports:
+    - port: 80
+      targetPort: 80

--- a/deploy/k8s-sandbox/manifests/21-ch-indexer.yaml
+++ b/deploy/k8s-sandbox/manifests/21-ch-indexer.yaml
@@ -1,0 +1,83 @@
+# SQS consumer: reads uploaded profiles from S3 (LocalStack) and writes rows to
+# ClickHouse (flamedb.samples) plus the flamegraph HTML back to S3. This is the
+# tail of the pipeline the compose "studio-only" setup never exercises.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ch-indexer
+  namespace: perf-studio
+  labels: { app: ch-indexer }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: ch-indexer }
+  template:
+    metadata:
+      labels: { app: ch-indexer }
+    spec:
+      # Compose gated the indexer on `localstack: service_healthy`; k8s has no
+      # depends_on, and the indexer resolves the SQS queue URL once at startup and
+      # does not retry. Without this wait it can boot before LocalStack is up,
+      # fail queue resolution, and silently never consume. Block until the SQS
+      # emulator reports running.
+      initContainers:
+        - name: wait-for-localstack
+          image: curlimages/curl:8.7.1
+          command:
+            - sh
+            - -c
+            - |
+              until curl -sf http://localstack:4566/_localstack/health | grep -q '"sqs": "running"'; do
+                echo "waiting for localstack sqs..."; sleep 3;
+              done
+      containers:
+        - name: ch-indexer
+          image: gprofiler-ps/ch-indexer:sandbox
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: SQS_QUEUE_URL
+              valueFrom: { configMapKeyRef: { name: studio-config, key: SQS_INDEXER_QUEUE_URL } }
+            - name: AWS_REGION
+              valueFrom: { configMapKeyRef: { name: studio-config, key: AWS_REGION } }
+            - name: AWS_ENDPOINT_URL
+              valueFrom: { configMapKeyRef: { name: studio-config, key: AWS_ENDPOINT_URL } }
+            - name: S3_BUCKET
+              valueFrom: { configMapKeyRef: { name: studio-config, key: BUCKET_NAME } }
+            - name: CLICKHOUSE_HOST
+              valueFrom: { configMapKeyRef: { name: studio-config, key: CLICKHOUSE_HOST } }
+            - name: CLICKHOUSE_USER
+              valueFrom: { secretKeyRef: { name: studio-secrets, key: CLICKHOUSE_USER } }
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom: { secretKeyRef: { name: studio-secrets, key: CLICKHOUSE_PASSWORD } }
+            - name: CLICKHOUSE_ADDR
+              value: "$(CLICKHOUSE_HOST):9000"
+            - name: CLICKHOUSE_USE_TLS
+              value: "false"
+            - name: CLICKHOUSE_STACKS_TABLE
+              value: flamedb.samples
+            - name: CLICKHOUSE_METRICS_TABLE
+              value: flamedb.metrics
+            - name: CLICKHOUSE_STACKS_BATCH_SIZE
+              value: "100000"
+            - name: CLICKHOUSE_METRICS_BATCH_SIZE
+              value: "1000"
+            - name: CONCURRENCY
+              value: "8"
+            - name: CACHE_SIZE
+              value: "2048"
+            - name: INDEXER_METRICS_ENABLED
+              valueFrom: { configMapKeyRef: { name: studio-config, key: INDEXER_METRICS_ENABLED } }
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom: { secretKeyRef: { name: studio-secrets, key: AWS_ACCESS_KEY_ID } }
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom: { secretKeyRef: { name: studio-secrets, key: AWS_SECRET_ACCESS_KEY } }
+            - name: GPROFILER_POSTGRES_HOST
+              valueFrom: { configMapKeyRef: { name: studio-config, key: POSTGRES_HOST } }
+            - name: GPROFILER_POSTGRES_PORT
+              valueFrom: { configMapKeyRef: { name: studio-config, key: POSTGRES_PORT } }
+            - name: GPROFILER_POSTGRES_DB_NAME
+              valueFrom: { configMapKeyRef: { name: studio-config, key: POSTGRES_DB } }
+            - name: GPROFILER_POSTGRES_USERNAME
+              valueFrom: { configMapKeyRef: { name: studio-config, key: POSTGRES_USER } }
+            - name: GPROFILER_POSTGRES_PASSWORD
+              valueFrom: { secretKeyRef: { name: studio-secrets, key: POSTGRES_PASSWORD } }

--- a/deploy/k8s-sandbox/manifests/22-logs-backend.yaml
+++ b/deploy/k8s-sandbox/manifests/22-logs-backend.yaml
@@ -1,0 +1,87 @@
+# Agent log ingest + periodic log-rotation. Co-located in one pod so they can
+# share the /logs volume (compose used a shared named volume; an emptyDir shared
+# by two containers is the pod-native equivalent and avoids needing RWX storage).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: logs-backend
+  namespace: perf-studio
+  labels: { app: logs-backend }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: logs-backend }
+  template:
+    metadata:
+      labels: { app: logs-backend }
+    spec:
+      securityContext:
+        runAsUser: 888
+        runAsGroup: 888
+        fsGroup: 888
+        # agents-logs-backend binds port 80 as non-root; allow the low-port bind
+        # the same way Docker does by default (see webapp for rationale).
+        sysctls:
+          - name: net.ipv4.ip_unprivileged_port_start
+            value: "0"
+      containers:
+        - name: agents-logs-backend
+          image: gprofiler-ps/agents-logs-backend:sandbox
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: ENV
+              value: open
+            - name: APP_LOG_FILE_PATH
+              value: /logs/agents-logs-app.log
+            - name: LOG_FILE_PATH
+              value: /logs/agents-logs.log
+            - name: GPROFILER_POSTGRES_HOST
+              valueFrom: { configMapKeyRef: { name: studio-config, key: POSTGRES_HOST } }
+            - name: GPROFILER_POSTGRES_PORT
+              valueFrom: { configMapKeyRef: { name: studio-config, key: POSTGRES_PORT } }
+            - name: GPROFILER_POSTGRES_DB_NAME
+              valueFrom: { configMapKeyRef: { name: studio-config, key: POSTGRES_DB } }
+            - name: GPROFILER_POSTGRES_USERNAME
+              valueFrom: { configMapKeyRef: { name: studio-config, key: POSTGRES_USER } }
+            - name: GPROFILER_POSTGRES_PASSWORD
+              valueFrom: { secretKeyRef: { name: studio-secrets, key: POSTGRES_PASSWORD } }
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: logs
+              mountPath: /logs
+        - name: periodic-tasks
+          image: gprofiler-ps/periodic-tasks:sandbox
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: PGHOST
+              valueFrom: { configMapKeyRef: { name: studio-config, key: POSTGRES_HOST } }
+            - name: PGPORT
+              valueFrom: { configMapKeyRef: { name: studio-config, key: POSTGRES_PORT } }
+            - name: PGDATABASE
+              valueFrom: { configMapKeyRef: { name: studio-config, key: POSTGRES_DB } }
+            - name: PGUSER
+              valueFrom: { configMapKeyRef: { name: studio-config, key: POSTGRES_USER } }
+            - name: PGPASSWORD
+              valueFrom: { secretKeyRef: { name: studio-secrets, key: POSTGRES_PASSWORD } }
+            - name: LOGROTATE_PATTERN
+              value: /logs/*.log
+            - name: LOGROTATE_SIZE
+              value: 15M
+          volumeMounts:
+            - name: logs
+              mountPath: /logs
+      volumes:
+        - name: logs
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: agents-logs-backend
+  namespace: perf-studio
+spec:
+  selector: { app: logs-backend }
+  ports:
+    - port: 80
+      targetPort: 80

--- a/deploy/k8s-sandbox/manifests/30-nginx.yaml
+++ b/deploy/k8s-sandbox/manifests/30-nginx.yaml
@@ -1,0 +1,62 @@
+# OPTIONAL TLS + basic-auth edge, only needed for the browser UI / Playwright
+# path. The API acceptance suite and the agent talk to http://webapp directly, so
+# the core sandbox works without this. The nginx config, .htpasswd and TLS cert
+# come from ConfigMap/Secrets the Makefile builds from the existing deploy/ files
+# (https_nginx.conf, .htpasswd, tls/), so there is one source of truth.
+#
+# Exposed as a NodePort so you can reach the console from the host at
+# https://<node-ip>:30443 (see `make -f Makefile.k8s k8s-url`).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  namespace: perf-studio
+  labels: { app: nginx }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: nginx }
+  template:
+    metadata:
+      labels: { app: nginx }
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.23.3
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 443
+          volumeMounts:
+            - name: conf
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+            - name: htpasswd
+              mountPath: /etc/nginx/.htpasswd
+              subPath: .htpasswd
+            - name: tls
+              mountPath: /etc/nginx/tls
+              readOnly: true
+      volumes:
+        - name: conf
+          configMap:
+            name: nginx-conf
+        - name: htpasswd
+          secret:
+            secretName: nginx-htpasswd
+        - name: tls
+          secret:
+            secretName: nginx-tls
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  namespace: perf-studio
+spec:
+  type: NodePort
+  selector: { app: nginx }
+  ports:
+    - name: https
+      port: 443
+      targetPort: 443
+      nodePort: 30443

--- a/deploy/k8s-sandbox/manifests/40-workloads.yaml
+++ b/deploy/k8s-sandbox/manifests/40-workloads.yaml
@@ -1,0 +1,163 @@
+# Realistic tenant workloads the agent DaemonSet enumerates over CRI. These give
+# the inventory genuine namespace/pod/container/process topology:
+#   team-a: checkout (2 replicas), web
+#   team-b: payments, search (2-container pod: app + sidecar)
+# Each container runs a deterministic CPU hot loop so py-spy produces stable,
+# recognizable frames. kubelet stamps every container with the
+# io.kubernetes.pod.{namespace,name,uid} + io.kubernetes.container.name labels
+# that heartbeat_metadata.py reads, so no in-app cooperation is required.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: checkout
+  namespace: team-a
+  labels: { app.kubernetes.io/name: checkout }
+spec:
+  replicas: 2
+  selector:
+    matchLabels: { app.kubernetes.io/name: checkout }
+  template:
+    metadata:
+      labels: { app.kubernetes.io/name: checkout }
+    spec:
+      containers:
+        - name: checkout
+          image: python:3.11-slim
+          imagePullPolicy: IfNotPresent
+          command: ["python3", "-c"]
+          args:
+            - |
+              import time
+              def hot_loop():
+                  total = 0
+                  for i in range(5_000_000):
+                      total += (i * i) % 7
+                  return total
+              while True:
+                  hot_loop()
+                  time.sleep(0.01)
+          resources:
+            requests: { cpu: 50m, memory: 32Mi }
+            limits: { cpu: 250m, memory: 128Mi }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: team-a
+  labels: { app.kubernetes.io/name: web }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app.kubernetes.io/name: web }
+  template:
+    metadata:
+      labels: { app.kubernetes.io/name: web }
+    spec:
+      containers:
+        - name: web
+          image: python:3.11-slim
+          imagePullPolicy: IfNotPresent
+          command: ["python3", "-c"]
+          args:
+            - |
+              import time
+              def serve():
+                  total = 0
+                  for i in range(3_000_000):
+                      total += (i * i) % 5
+                  return total
+              while True:
+                  serve()
+                  time.sleep(0.02)
+          resources:
+            requests: { cpu: 50m, memory: 32Mi }
+            limits: { cpu: 250m, memory: 128Mi }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payments
+  namespace: team-b
+  labels: { app.kubernetes.io/name: payments }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app.kubernetes.io/name: payments }
+  template:
+    metadata:
+      labels: { app.kubernetes.io/name: payments }
+    spec:
+      containers:
+        - name: payments
+          image: python:3.11-slim
+          imagePullPolicy: IfNotPresent
+          command: ["python3", "-c"]
+          args:
+            - |
+              import time
+              def settle():
+                  total = 0
+                  for i in range(4_000_000):
+                      total += (i * i) % 11
+                  return total
+              while True:
+                  settle()
+                  time.sleep(0.01)
+          resources:
+            requests: { cpu: 50m, memory: 32Mi }
+            limits: { cpu: 250m, memory: 128Mi }
+---
+# Multi-container pod: proves container-scope resolution can distinguish two
+# containers inside the same pod.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: search
+  namespace: team-b
+  labels: { app.kubernetes.io/name: search }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app.kubernetes.io/name: search }
+  template:
+    metadata:
+      labels: { app.kubernetes.io/name: search }
+    spec:
+      containers:
+        - name: search-app
+          image: python:3.11-slim
+          imagePullPolicy: IfNotPresent
+          command: ["python3", "-c"]
+          args:
+            - |
+              import time
+              def index():
+                  total = 0
+                  for i in range(4_500_000):
+                      total += (i * i) % 13
+                  return total
+              while True:
+                  index()
+                  time.sleep(0.01)
+          resources:
+            requests: { cpu: 50m, memory: 32Mi }
+            limits: { cpu: 250m, memory: 128Mi }
+        - name: search-sidecar
+          image: python:3.11-slim
+          imagePullPolicy: IfNotPresent
+          command: ["python3", "-c"]
+          args:
+            - |
+              import time
+              def tail():
+                  total = 0
+                  for i in range(1_000_000):
+                      total += (i * i) % 3
+                  return total
+              while True:
+                  tail()
+                  time.sleep(0.05)
+          resources:
+            requests: { cpu: 25m, memory: 32Mi }
+            limits: { cpu: 100m, memory: 64Mi }

--- a/deploy/k8s-sandbox/manifests/50-agent-daemonset.yaml
+++ b/deploy/k8s-sandbox/manifests/50-agent-daemonset.yaml
@@ -1,0 +1,72 @@
+# The real gProfiler agent, one per node (prod shape). THIS is what the sandbox
+# exists to exercise: unlike docker-compose, a DaemonSet on a real node can read
+# the node's CRI socket and enumerate genuine k8s pods/containers.
+#
+# Why it lights up namespace/pod/container inventory (see the agent code):
+#   * granulate_utils CriClient talks to /run/containerd/containerd.sock, but it
+#     resolves that path under HOST_ROOT_PREFIX = /proc/1/root. With hostPID:true
+#     PID 1 is the host init, so /proc/1/root is the node root fs and the socket
+#     is reachable. privileged:true grants the access (and lets py-spy ptrace).
+#   * CRI returns the io.kubernetes.pod.{namespace,name,uid} + container.name
+#     labels that heartbeat_metadata.py turns into inventory rows.
+#   * get_process_container_id() maps every host PID to its container; hostPID
+#     is required to see PIDs outside the agent's own container.
+#
+# IMPORTANT: use the SOURCE-built agent image (make -f Makefile.k8s agent-build).
+# The container-inventory heartbeat is a fork feature; the public intel/gprofiler
+# image does not emit it, so the pod/container tabs would stay empty.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: gprofiler-agent
+  namespace: perf-studio
+  labels: { app: gprofiler-agent }
+spec:
+  selector:
+    matchLabels: { app: gprofiler-agent }
+  template:
+    metadata:
+      labels: { app: gprofiler-agent }
+    spec:
+      hostPID: true
+      containers:
+        - name: gprofiler-agent
+          image: gprofiler-e2e-agent:src
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          command: ["/gprofiler"]
+          args:
+            - --server-host=http://webapp
+            - --api-server=http://webapp
+            - --token=$(GPROFILER_TOKEN)
+            - --service-name=k8s-sandbox
+            - --upload-results
+            - --enable-heartbeat-server
+            - --heartbeat-interval=10
+            - --perf-mode=none
+            - --output-dir=/tmp/gprofiler_output
+            - --dont-send-logs
+            - --disable-pidns-check
+          env:
+            - name: GPROFILER_IN_CONTAINER
+              value: "1"
+            - name: GPROFILER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: gprofiler-agent-token
+                  key: token
+            # The agent's own identity (downward API), reported alongside inventory.
+            - name: POD_NAMESPACE
+              valueFrom: { fieldRef: { fieldPath: metadata.namespace } }
+            - name: POD_NAME
+              valueFrom: { fieldRef: { fieldPath: metadata.name } }
+            - name: NODE_NAME
+              valueFrom: { fieldRef: { fieldPath: spec.nodeName } }
+          resources:
+            requests: { cpu: 100m, memory: 128Mi }
+            limits: { cpu: "1", memory: 512Mi }
+      # Tolerate control-plane taints so the DaemonSet also lands on a
+      # single-node kind/minikube cluster's control-plane node.
+      tolerations:
+        - operator: Exists

--- a/deploy/k8s-sandbox/tests/Dockerfile
+++ b/deploy/k8s-sandbox/tests/Dockerfile
@@ -1,0 +1,25 @@
+# In-cluster acceptance runner for the k8s sandbox.
+#
+# BUILD CONTEXT MUST BE THE STUDIO REPO ROOT (gprofiler-performance-studio/) so
+# it can copy both the shared HTTP harness from the compose e2e suite and the
+# k8s-specific tests:
+#
+#   docker build -f deploy/k8s-sandbox/tests/Dockerfile -t gprofiler-ps/k8s-tests:sandbox .
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /work
+
+RUN pip install --no-cache-dir \
+    pytest==8.2.0 \
+    requests==2.32.3
+
+# Shared request/response harness (single source of truth with the compose suite).
+COPY src/tests/e2e/harness.py /work/harness.py
+# k8s-specific real-topology tests.
+COPY deploy/k8s-sandbox/tests/conftest.py /work/conftest.py
+COPY deploy/k8s-sandbox/tests/test_k8s_inventory.py /work/test_k8s_inventory.py
+
+CMD ["pytest", "-q", "-rA", "test_k8s_inventory.py"]

--- a/deploy/k8s-sandbox/tests/conftest.py
+++ b/deploy/k8s-sandbox/tests/conftest.py
@@ -1,0 +1,14 @@
+"""Fixtures for the k8s-sandbox acceptance suite.
+
+Reuses the HTTP harness from the compose e2e suite (copied in at image build
+time) so the request/response contract stays in one place. Runs in-cluster as a
+Job in the perf-studio namespace, reaching the backend at http://webapp.
+"""
+import pytest
+
+from harness import Client
+
+
+@pytest.fixture(scope="session")
+def client() -> Client:
+    return Client()

--- a/deploy/k8s-sandbox/tests/job-api.yaml
+++ b/deploy/k8s-sandbox/tests/job-api.yaml
@@ -1,0 +1,21 @@
+# Runs the real-topology acceptance suite (AT-K1..K5) in-cluster against the live
+# webapp Service. Recreate it each run (kubectl delete --ignore-not-found first).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: k8s-acceptance
+  namespace: perf-studio
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels: { app: k8s-acceptance }
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: tests
+          image: gprofiler-ps/k8s-tests:sandbox
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: E2E_BASE_URL
+              value: http://webapp

--- a/deploy/k8s-sandbox/tests/test_k8s_inventory.py
+++ b/deploy/k8s-sandbox/tests/test_k8s_inventory.py
@@ -1,0 +1,129 @@
+"""Real-cluster acceptance tests (AT-K1 .. AT-K5).
+
+Unlike the compose e2e suite (which POSTs *synthetic* heartbeats to fabricate an
+inventory), these assert against inventory produced by a REAL gProfiler agent
+DaemonSet enumerating the node's CRI socket. That is the capability docker-compose
+cannot provide (no container runtime -> empty inventory), so this is the layer
+that actually proves namespace/pod/container/process discovery and scope
+resolution under Kubernetes.
+
+Prerequisite: the sandbox is up with the SOURCE-built agent and the tenant
+workloads deployed (see deploy/k8s-sandbox/Makefile.k8s):
+
+    make -f Makefile.k8s k8s-up
+    make -f Makefile.k8s k8s-test
+
+The agent reports under service_name "k8s-sandbox". Because it enumerates the
+whole node, inventory also contains system/studio containers; every assertion
+therefore looks for the specific tenant entities we deployed rather than exact
+totals, which keeps the suite robust on any cluster.
+"""
+import json
+import time
+
+import harness as h
+import pytest
+
+AGENT_SERVICE = "k8s-sandbox"
+
+# What deploy/k8s-sandbox/manifests/40-workloads.yaml creates.
+EXPECTED_NAMESPACES = ["team-a", "team-b"]
+EXPECTED_PODS = ["checkout", "web", "payments", "search"]
+EXPECTED_CONTAINERS = ["checkout", "web", "payments", "search-app", "search-sidecar"]
+
+# The agent inventory refresh is 30s and heartbeats every 10s; give the first
+# full snapshot generous time to propagate on a cold cluster.
+DISCOVERY_TIMEOUT_S = 240
+POLL_INTERVAL_S = 5
+
+
+def _status_blob(client, scope):
+    """workload_status for a scope, as (parsed, serialized) for tolerant matching.
+
+    Per-scope row field names are intentionally not hard-coded; we match on the
+    serialized document so the test doesn't break if the response key casing
+    changes. tabCounts and host rows use the same stable contract as the compose
+    suite.
+    """
+    status = h.get_workload_status(client, scope=scope)
+    return status, json.dumps(status)
+
+
+def _wait_for(client, scope, needles):
+    """Poll workload_status[scope] until every needle appears, or time out."""
+    deadline = time.time() + DISCOVERY_TIMEOUT_S
+    missing = list(needles)
+    blob = ""
+    while time.time() < deadline:
+        _, blob = _status_blob(client, scope)
+        missing = [n for n in needles if n not in blob]
+        if not missing:
+            return blob
+        time.sleep(POLL_INTERVAL_S)
+    pytest.fail(
+        f"scope={scope}: timed out after {DISCOVERY_TIMEOUT_S}s waiting for "
+        f"{missing}. Is the SOURCE-built agent DaemonSet running with hostPID + "
+        f"privileged and a reachable containerd socket? Last blob: {blob[:2000]}"
+    )
+
+
+def test_at_k1_agent_registers_as_host(client):
+    """AT-K1: the real agent DaemonSet shows up as a host under its service."""
+    deadline = time.time() + DISCOVERY_TIMEOUT_S
+    hosts = []
+    while time.time() < deadline:
+        status = h.get_workload_status(client, scope="host", service_name=AGENT_SERVICE)
+        hosts = [r["hostname"] for r in h.rows_for(status, AGENT_SERVICE)]
+        if hosts:
+            break
+        time.sleep(POLL_INTERVAL_S)
+    assert hosts, f"no host reported for service {AGENT_SERVICE!r} within {DISCOVERY_TIMEOUT_S}s"
+
+
+def test_at_k2_namespaces_from_real_cri(client):
+    """AT-K2: tenant namespaces are discovered from the node's CRI, not fabricated."""
+    blob = _wait_for(client, "namespace", EXPECTED_NAMESPACES)
+    for ns in EXPECTED_NAMESPACES:
+        assert ns in blob
+
+
+def test_at_k3_pods_from_real_cri(client):
+    """AT-K3: pods for each tenant workload appear in the pod scope."""
+    # Deployment pods are named <workload>-<replicaset>-<suffix>; the agent
+    # derives the workload name, so matching the workload prefix is sufficient.
+    blob = _wait_for(client, "pod", EXPECTED_PODS)
+    for pod in EXPECTED_PODS:
+        assert pod in blob
+
+
+def test_at_k4_containers_including_multi_container_pod(client):
+    """AT-K4: every container is discovered, including both in the 2-container pod."""
+    blob = _wait_for(client, "container", EXPECTED_CONTAINERS)
+    for container in EXPECTED_CONTAINERS:
+        assert container in blob, f"missing container {container!r}"
+
+
+def test_at_k5_host_scope_start_resolves_real_agent(client):
+    """AT-K5: a host-scope start resolves the real agent's host and creates a command.
+
+    Uses the same start/stop contract the compose suite validates (AT-S5), but the
+    target host is the *real* DaemonSet host discovered from live inventory, so
+    this proves the studio resolves and dispatches to an actual agent (not a
+    synthetic heartbeat).
+    """
+    status = h.get_workload_status(client, scope="host", service_name=AGENT_SERVICE)
+    hosts = [r["hostname"] for r in h.rows_for(status, AGENT_SERVICE)]
+    assert hosts, "no real agent host to target"
+    host = hosts[0]
+
+    started = h.submit(
+        client,
+        h.start_request(AGENT_SERVICE, target_scope="host", target_hosts={host: []}),
+    )
+    assert started.status_code == 200, started.text
+
+    stopped = h.submit(
+        client,
+        h.stop_request(AGENT_SERVICE, target_scope="host", stop_level="host", target_hosts={host: []}),
+    )
+    assert stopped.status_code == 200, stopped.text

--- a/docs/K8S_SANDBOX.md
+++ b/docs/K8S_SANDBOX.md
@@ -1,0 +1,150 @@
+# Kubernetes sandbox for workload-level profiling
+
+Architecture and rationale for the local Kubernetes sandbox that validates
+workload-level (namespace / pod / container / process) profiling against a
+**real cluster topology**.
+
+> **Operational runbook** (prerequisites, `make` targets, quick start) lives next
+> to the code: [`deploy/k8s-sandbox/K8S_SANDBOX.md`](../deploy/k8s-sandbox/K8S_SANDBOX.md).
+> This page is the conceptual/architecture companion.
+
+## Why a Kubernetes sandbox (and not just docker-compose)
+
+The compose harness ([`deploy/E2E_HARNESS.md`](../deploy/E2E_HARNESS.md)) runs the
+full stack fast and exercises the S3→SQS→indexer→ClickHouse→flamegraph pipeline,
+but it **cannot** produce real namespaces/pods/containers. Workload-level
+profiling resolves those scopes, and the agent builds that inventory in
+`gprofiler/metadata/heartbeat_metadata.py` by asking `granulate_utils`'
+`ContainersClient` to enumerate the node's containers via the **container-runtime
+socket** (CRI at `/run/containerd/containerd.sock`, or Docker) — **not** the
+Kubernetes API server. It reads the kubelet labels
+`io.kubernetes.pod.namespace`, `io.kubernetes.pod.name`,
+`io.kubernetes.container.name` off each container.
+
+Under docker-compose there is no such socket for the agent, so it logs
+`No container runtime found for heartbeat workload inventory` and the
+pod/container/namespace tabs are only exercised with *synthetic* heartbeats. On a
+real node the socket exists, so the inventory is **real**. That gap is the reason
+this sandbox exists.
+
+| Layer | Orchestrator | Proves | Can't do |
+|-------|--------------|--------|----------|
+| `deploy/Makefile.e2e` (compose) | Docker Compose | fast API + full artifact pipeline | no real namespaces/pods/containers |
+| `deploy/k8s-sandbox` (this) | kind / minikube | **real namespace/pod/container/process inventory + scope resolution** | heavier, slower inner loop |
+
+## What is a kind cluster?
+
+**kind = "Kubernetes IN Docker."** The entire cluster *node* is itself a single
+Docker container running the `kindest/node` image. Inside that container, an init
+system (systemd) boots a container runtime and the kubelet, and Kubernetes then
+runs all workloads as pods *inside* the node container. It is nested containers:
+
+```
+Your Linux host
+└─ Docker
+   └─ kind node  (container: kindest/node:v1.30.0)   <- "the cluster"
+      ├─ systemd (PID 1)
+      │   ├─ containerd.service     ← the CRI runtime that runs every pod
+      │   ├─ kubelet.service        ← node agent: talks to the API server, drives containerd
+      │   └─ systemd-journald
+      └─ pods (run by containerd, orchestrated by Kubernetes)
+```
+
+minikube is the same idea using a VM (or a container). kind is lighter and
+containerd-native, which is why it is the default here and recommended for CI.
+Both give a **hermetic, disposable** cluster: create → test → destroy, nothing
+touches real infrastructure.
+
+## Topology: what runs as systemd vs. as pods
+
+This is the key mental model. Inside the kind node, **only three things run under
+systemd** — everything else (including Kubernetes' own control plane) runs as
+pods managed by the kubelet + containerd:
+
+**systemd services (inside the node container):**
+
+| Unit | Role |
+|------|------|
+| `containerd.service` | container runtime (CRI) that actually runs all pods |
+| `kubelet.service` | node agent; `--container-runtime-endpoint=unix:///run/containerd/containerd.sock` |
+| `systemd-journald.service` | logging |
+
+Notably, the kubelet's CRI endpoint is the **exact socket the agent DaemonSet
+reads** (via `/proc/1/root`, see below) to enumerate workloads.
+
+**Everything else is a pod:**
+
+- **Kubernetes control plane** (`kube-system`, run as *static pods*):
+  `kube-apiserver`, `etcd`, `kube-scheduler`, `kube-controller-manager`, plus
+  `kube-proxy`, `kindnet` (CNI), `coredns`, and `local-path-provisioner`.
+- **Performance Studio stack** (`perf-studio` namespace): `webapp`, `postgres`,
+  `clickhouse`, `ch-rest-service`, `ch-indexer`, `logs-backend` (2 containers),
+  `nginx`, `localstack`, and the **`gprofiler-agent` DaemonSet**.
+- **Tenant workloads**: `team-a` (`checkout` ×2, `web`) and `team-b`
+  (`payments`, `search` — a 2-container pod).
+
+So even etcd and the API server are pods — a kind design choice. Contrast
+docker-compose, where each service is a bare container on a bridge network with
+**no kubelet, no containerd-as-CRI, and no pods**, which is exactly why the agent
+finds "no container runtime" there but discovers real pods/namespaces/containers
+here.
+
+## How the agent DaemonSet reaches the CRI socket
+
+`granulate_utils` resolves the socket path under `HOST_ROOT_PREFIX = /proc/1/root`
+(`granulate_utils/linux/ns.py`). The mechanism is two pod settings, not a
+bind-mount:
+
+- **`hostPID: true`** → PID 1 in the pod is the host (node) init, so
+  `/proc/1/root` is the node root filesystem and
+  `/proc/1/root/run/containerd/containerd.sock` is the node's real CRI socket.
+  `hostPID` also lets the agent see every node PID to map processes → containers.
+- **`privileged: true`** → grants access to that socket and lets py-spy `ptrace`
+  the target workloads.
+
+> **Use the source-built agent.** The container-inventory heartbeat is a fork
+> feature, so the public `intel/gprofiler:latest` image will **not** populate the
+> pod/container tabs.
+
+## Data flow
+
+```
+ kind node (containerd)
+   ns team-a: checkout(x2), web       ns team-b: payments, search(app+sidecar)
+          ▲ enumerated via CRI (/proc/1/root/run/containerd/...)
+   gprofiler-agent DaemonSet ─ heartbeat/commands ─► webapp ─► postgres
+    (hostPID, privileged)               │
+                                        └─ upload ─► S3 (LocalStack)
+                                                       ▼
+                                             SQS ─► ch-indexer ─► ClickHouse
+                                                       ▼
+                                             nginx NodePort :30443 (UI)
+```
+
+## Verified end-to-end
+
+Brought up on a single-node **kind v1.30** cluster (containerd 1.7) and confirmed:
+
+- Agent DaemonSet connects and heartbeats with **no** `No container runtime
+  found` error (contrast compose) — it reached the node CRI socket.
+- `workload_status` reported real topology — `tabCounts` `{service:1, host:1,
+  namespace:5, pod:23, container:25, process:93}` — including tenant namespaces
+  `team-a`/`team-b` and the 2-container `search` pod resolved as distinct
+  `search-app` + `search-sidecar`.
+- Acceptance suite `AT-K1..K5` passed (5/5).
+- **Full artifact pipeline closed in-cluster**: a host-scope start made the agent
+  profile the real workloads and upload; the webapp wrote collapsed stacks to S3
+  (`products/k8s-sandbox/stacks/...gz`) and enqueued SQS; the indexer consumed it,
+  inserted 27 rows into `flamedb.samples`, and wrote the rendered
+  `..._adhoc_flamegraph.html` back to S3 — all against LocalStack, no real AWS.
+
+Two k8s-specific fixes came out of that run:
+
+- **Non-root low-port bind** (webapp, agents-logs-backend run as non-root and
+  bind port 80): Docker allows this via its default
+  `net.ipv4.ip_unprivileged_port_start=0`; Kubernetes does not, so those pods set
+  that (safe) sysctl explicitly.
+- **Indexer startup ordering**: compose gated it on `localstack: service_healthy`;
+  k8s has no `depends_on` and the indexer resolves the SQS URL once without retry,
+  so it can boot before LocalStack and never consume. An init-container now waits
+  for LocalStack's SQS to report running.

--- a/docs/K8S_SANDBOX.md
+++ b/docs/K8S_SANDBOX.md
@@ -50,10 +50,115 @@ Your Linux host
       └─ pods (run by containerd, orchestrated by Kubernetes)
 ```
 
-minikube is the same idea using a VM (or a container). kind is lighter and
-containerd-native, which is why it is the default here and recommended for CI.
-Both give a **hermetic, disposable** cluster: create → test → destroy, nothing
-touches real infrastructure.
+Both kind and minikube give a **hermetic, disposable** cluster: create → test →
+destroy, nothing touches real infrastructure. The `Makefile.k8s` supports either
+via `CLUSTER=kind|minikube` (see [the runbook](../deploy/k8s-sandbox/K8S_SANDBOX.md)).
+
+## kind vs. minikube (and why kind is the default)
+
+Both create a throwaway local Kubernetes cluster; the difference is *how* the node
+is run and which container runtime lives inside it — which matters a lot here,
+because the whole point of this sandbox is that the agent reads the node's **CRI
+socket**.
+
+| | **kind** | **minikube** |
+|---|---|---|
+| Name | "Kubernetes **IN D**ocker" | "mini Kubernetes" |
+| Node runs as | a Docker container (`kindest/node`) | a VM *or* a container ("drivers": docker, kvm2, virtualbox, none, …) |
+| Runtime inside node | **containerd** (native) — socket at `/run/containerd/containerd.sock` | docker by default; containerd only with `--container-runtime=containerd` |
+| Install | single static binary, needs Docker | single binary, but drivers add moving parts |
+| Weight / speed | very light, fast, CI-standard | heavier; more features (addons, dashboard, LoadBalancer tunnels) |
+| Best fit | automated testing / CI | general local dev with extras |
+
+Why kind is the default for this sandbox:
+
+1. **containerd-native, prod-like path.** A real production node runs containerd
+   and exposes the CRI socket the agent reads (`/run/containerd/containerd.sock`).
+   kind gives exactly that out of the box. minikube's default docker driver would
+   hand the agent `docker.sock` instead — a different, less prod-like code path —
+   unless you explicitly pass `--container-runtime=containerd`.
+2. **Lighter + fewer choices.** One binary, only needs Docker; no VM/driver
+   matrix to reason about.
+3. **CI-standard.** Easiest to graduate this sandbox into CI later.
+
+minikube is **not wrong** — with `--container-runtime=containerd` it produces the
+same containerd CRI topology and the manifests/tests are identical. It's just
+heavier and has more environment-specific setup.
+
+## Challenge: minikube's docker driver won't boot on this host
+
+`CLUSTER=minikube` is fully wired into `Makefile.k8s`, but when validated on the
+build host it could **not** bring up a cluster. Documented here so the next person
+doesn't burn time rediscovering it.
+
+**Symptom.** `minikube start --driver=docker --container-runtime=containerd`
+creates the `kicbase` node container, which then exits immediately at
+`exec /sbin/init`:
+
+```
++ exec /sbin/init
+Couldn't find an alternative telinit implementation to spawn.: container exited unexpectedly
+X Exiting due to GUEST_PROVISION_EXIT_UNEXPECTED: Failed to start host ...
+```
+
+i.e. systemd cannot come up as PID 1 inside minikube's node container, so the
+kubelet/API server never start.
+
+**What was tried (all reproduced the same failure):**
+
+| Attempt | Result |
+|---------|--------|
+| current kicbase `v0.0.50` (Ubuntu 24.04) + containerd | `exec /sbin/init` exits |
+| older kicbase `v0.0.44` + `--kubernetes-version=v1.30.0` | same |
+| `--force-systemd` | same |
+
+**Root cause.** minikube's node image can't run systemd-as-PID-1 in this
+particular **Docker 28.x + cgroup v2 + AWS `6.8.0` kernel** combination — the
+container's init bails before systemd takes over. Notably, kind's
+`kindest/node:v1.30.0` boots systemd fine on the *exact same host* (that's what
+the running sandbox uses), so this is specific to how minikube constructs/runs its
+node container, not a general "systemd-in-container is impossible here" problem.
+
+**Why the other minikube drivers weren't used.** VM drivers (`kvm2`,
+`virtualbox`) need nested virtualization this cloud VM doesn't expose; the `none`
+driver installs the kubelet **directly on the host** (invasive, root-level, would
+mutate the host) and was intentionally avoided. That leaves the docker driver as
+the only in-scope option — and it's the one that fails.
+
+**Resolution / takeaway.** Use **kind** here (the default). On a laptop or CI
+runner where minikube's docker driver boots normally, `CLUSTER=minikube` works
+with the *same* manifests and acceptance suite — nothing else changes. This is the
+concrete, practical reason kind is the default for this sandbox, beyond the
+containerd-native argument above.
+
+## How to use it (kind or minikube)
+
+All flow through `deploy/k8s-sandbox/Makefile.k8s`. Pick the cluster tool with the
+`CLUSTER` variable (default `kind`):
+
+```bash
+cd gprofiler-performance-studio/deploy/k8s-sandbox
+
+# --- kind (default, recommended) ---
+make -f Makefile.k8s k8s-all           # cluster + build + load + deploy + token
+make -f Makefile.k8s k8s-test          # AT-K1..K5 real-topology acceptance
+make -f Makefile.k8s k8s-status        # live workload inventory (all scopes)
+make -f Makefile.k8s k8s-url           # -> https://localhost:30443 (admin/admin)
+make -f Makefile.k8s k8s-down-all      # delete the whole cluster
+
+# --- minikube (same manifests/tests; needs a host where its docker driver boots) ---
+make -f Makefile.k8s k8s-all  CLUSTER=minikube CLUSTER_NAME=gprofiler-mk
+make -f Makefile.k8s k8s-test CLUSTER=minikube CLUSTER_NAME=gprofiler-mk
+make -f Makefile.k8s k8s-url  CLUSTER=minikube CLUSTER_NAME=gprofiler-mk   # -> https://<minikube ip>:30443
+make -f Makefile.k8s k8s-down-all CLUSTER=minikube CLUSTER_NAME=gprofiler-mk
+```
+
+The only thing `CLUSTER` changes is cluster lifecycle + image loading (`kind load
+docker-image` vs `minikube image load`) and the URL; every manifest, ConfigMap,
+Secret, the agent DaemonSet, and the acceptance suite are identical. Use a
+distinct `CLUSTER_NAME` (e.g. `gprofiler-mk`) if you want to run minikube
+alongside an existing kind cluster, and note kind already binds host port `30443`
+— map minikube elsewhere (e.g. `--ports=30444:30443`) to avoid a collision.
 
 ## Topology: what runs as systemd vs. as pods
 


### PR DESCRIPTION
## Summary

Adds a self-contained, disposable **Kubernetes** sandbox (kind/minikube) that runs the full Performance Studio stack **plus a real gProfiler agent DaemonSet** and tenant workloads, so the workload-level (namespace/pod/container/process) profiling flow can be exercised against a **genuine cluster topology**.

This is a **separate, additive layer** alongside the docker-compose harness (`deploy/E2E_HARNESS.md`) — it does not replace it.

## Why (the one thing compose can't do)

Workload-level profiling resolves namespace/pod/container/process scopes. The agent builds that inventory (`gprofiler/metadata/heartbeat_metadata.py`) by enumerating the node's containers over the **CRI socket** (`/run/containerd/containerd.sock`) — not the k8s API. Under docker-compose there is no such socket for the agent (`No container runtime found` → empty inventory), so those tabs are only exercised with synthetic heartbeats. On a real node the inventory is **real**.

The DaemonSet reaches the node CRI socket via `/proc/1/root` using `hostPID: true` + `privileged: true` (granulate_utils resolves under `HOST_ROOT_PREFIX=/proc/1/root`). Uses the source-built agent, since the container-inventory heartbeat is a fork feature.

## What's included

- `deploy/k8s-sandbox/manifests/` — full stack (webapp, postgres, clickhouse, ch-rest, ch-indexer, logs-backend, nginx, LocalStack), tenant workloads across `team-a`/`team-b` (incl. a 2-container pod), and the agent DaemonSet.
- `deploy/k8s-sandbox/Makefile.k8s` — mirrors `Makefile.e2e` (`k8s-all`, `k8s-cluster`, `k8s-images`, `k8s-load`, `k8s-up`, `k8s-status`, `k8s-test`, `k8s-start/stop`, `k8s-flamegraph`, `k8s-down/down-all`); supports `CLUSTER=kind|minikube`.
- `deploy/k8s-sandbox/tests/` — in-cluster real-topology acceptance suite (AT-K1..K5) as a Job, reusing the compose suite's HTTP harness.
- `docs/K8S_SANDBOX.md` — architecture, "what is kind", and the pods-vs-systemd topology breakdown; `deploy/k8s-sandbox/K8S_SANDBOX.md` — operational runbook.

## Verified end-to-end (kind v1.30, containerd 1.7)

- Agent DaemonSet connects/heartbeats with **no** `No container runtime found` error.
- `workload_status` real topology: `tabCounts {service:1, host:1, namespace:5, pod:23, container:25, process:93}`, incl. `team-a`/`team-b` and the 2-container `search` pod split into `search-app` + `search-sidecar`.
- Acceptance suite **AT-K1..K5 (5 passed)**.
- **Full artifact pipeline closed in-cluster**: agent profiles real workloads → upload → webapp → S3 (stacks `.gz`) → SQS → indexer → ClickHouse (27 rows) → flamegraph HTML back to S3 — all against LocalStack, no real AWS.

### k8s-specific fixes found during verification
- **Non-root low-port bind** (webapp, agents-logs-backend bind :80 as non-root): added the safe `net.ipv4.ip_unprivileged_port_start=0` sysctl (Docker allows this by default; k8s doesn't).
- **Indexer startup ordering**: added an init-container that waits for LocalStack SQS (compose used `depends_on: service_healthy`; the indexer resolves the SQS URL once without retry).

## Test plan

- [ ] `cd deploy/k8s-sandbox && make -f Makefile.k8s k8s-all` (kind) brings up the stack + agent
- [ ] `make -f Makefile.k8s k8s-status` shows real namespace/pod/container inventory
- [ ] `make -f Makefile.k8s k8s-test` passes AT-K1..K5
- [ ] `make -f Makefile.k8s k8s-start && make -f Makefile.k8s k8s-flamegraph` shows artifacts in LocalStack S3
- [ ] `make -f Makefile.k8s k8s-down-all` tears the cluster down

Made with Cursor

Made with [Cursor](https://cursor.com)