### PR TITLE
test(k8s-sandbox): Spark-on-k8s workload + per-thread Java profiling + 3-layer harness docs

### DIFF
--- a/deploy/E2E_HARNESS.md
+++ b/deploy/E2E_HARNESS.md
@@ -19,6 +19,13 @@ that the studio-only setup never touches.
                                               UI / flamegraph API (nginx :4433)
 ```
 
+> **Where this fits.** This harness is **Layer 2** of a three-layer test setup
+> (fast unit → this compose harness → a kind/minikube Kubernetes sandbox). See
+> [The three-layer test harness](#the-three-layer-test-harness) below for how the
+> layers differ and how to invoke each. Layer 3 lives in
+> [`k8s-sandbox/`](k8s-sandbox/K8S_SANDBOX.md) (architecture:
+> [`../docs/K8S_SANDBOX.md`](../docs/K8S_SANDBOX.md)).
+
 ## Files
 
 | File | Purpose |
@@ -206,32 +213,100 @@ where it's verified. Keep these in mind:
 - **Prerequisites** above (TLS + `.htpasswd`) are one-time and cross-platform
   (need `openssl` + `htpasswd`; `htpasswd` ships with `apache2-utils` on Ubuntu).
 
-## Test layers
+## The three-layer test harness
 
-1. **Fast unit/spec** (no stack) — PR gate: `gprofiler/tests_fast/` and
-   `gprofiler-performance-studio/src/tests/spec/` + the frontend `node --test`.
-2. **API acceptance** (this harness) — `src/tests/e2e/`, run via
-   `make -f Makefile.e2e e2e-test`. 15 in-network pytest cases covering the
-   spec's **AT-S1 .. AT-S15** against the live stack: inventory/tab-counts (S1–S4),
-   host/service/process resolution + command creation (S5–S7), empty-resolution
-   422 (S8), PMU rejection (S9), continuous subscription auto-enrollment (S10–S13),
-   and legacy/partial-inventory compatibility (S14–S15).
-3. **Full-pipeline smoke** — the real agent path above proves S3/SQS/indexer/
-   ClickHouse/flamegraph (AT-A1–A8). Verified with the source-built agent.
-4. **Playwright UI e2e** — `src/tests/playwright/`, run via
-   `make -f Makefile.e2e e2e-ui-test`. Drives the console through the internal
-   nginx (basic auth + self-signed TLS) using the official Playwright browser
-   image, asserting the start/stop confirmation flow (dry-run validation +
-   submit). The STOP case is the direct UI regression test for the
-   host-level-stop bug.
+Three layers test the workload-level profiling flow at increasing fidelity. The
+key difference between layers is **how the workload inventory is produced** —
+fabricated in-code, POSTed as synthetic heartbeats, or enumerated for real from a
+Kubernetes node's container runtime.
 
-Run everything against a running stack:
+| Layer | What runs | Inventory source | Proves | Invoke |
+|-------|-----------|------------------|--------|--------|
+| **1. Fast unit/spec** | no stack | in-code fixtures | backend/agent pure logic (PR gate) | `pytest` / `node --test` |
+| **2. Compose harness** (this doc) | full studio via Docker Compose | **synthetic** heartbeats (+ real-agent pipeline) | studio logic + S3→SQS→indexer→ClickHouse→flamegraph | `make -f Makefile.e2e …` |
+| **3. kind/minikube sandbox** | full studio on Kubernetes | **real** CRI enumeration by a DaemonSet | real namespace/pod/container/process discovery + scoping | `make -f Makefile.k8s …` |
+
+### Layer 1 — fast unit/spec (no stack, PR gate)
+
+No services required; runs in seconds.
 
 ```bash
-make -f Makefile.e2e e2e-up        # or e2e-up-src for the source-built agent
-make -f Makefile.e2e e2e-test      # API acceptance (AT-S1..S15)
-make -f Makefile.e2e e2e-ui-test   # Playwright UI acceptance
+# studio backend spec (request builder, PMU/capacity, profiling-request logic)
+pytest -q gprofiler-performance-studio/src/tests/spec
+# studio frontend unit tests
+cd gprofiler-performance-studio/src/gprofiler/frontend && node --test
+# agent-side fast logic (heartbeat inventory, command queue) — in the agent repo
+pytest -q gprofiler/tests_fast
 ```
+
+### Layer 2 — compose harness (this doc)
+
+Full studio + a real agent profiling a deterministic sample app, plus the
+complete artifact pipeline. Three test families:
+
+- **API acceptance `AT-S1..S15`** — 15 in-network pytest cases (`src/tests/e2e/`)
+  driving the live stack with **synthetic** heartbeats: inventory/tab-counts
+  (S1–S4), host/service/process resolution + command creation (S5–S7),
+  empty-resolution 422 (S8), PMU rejection (S9), continuous-subscription
+  auto-enrollment (S10–S13), legacy/partial-inventory compatibility (S14–S15).
+- **Full-pipeline smoke `AT-A1..A8`** — the real source-built agent proves
+  S3 → SQS → indexer → ClickHouse → flamegraph.
+- **Playwright UI e2e** — drives the console through nginx (basic auth +
+  self-signed TLS), asserting the start/stop confirmation flow (the STOP case is
+  the regression test for the host-level-stop bug).
+
+```bash
+cd deploy
+make -f Makefile.e2e e2e-up            # bring up (or e2e-up-src for source-built agent)
+make -f Makefile.e2e e2e-test          # AT-S1..S15 API acceptance
+make -f Makefile.e2e e2e-start \
+  && make -f Makefile.e2e e2e-flamegraph   # AT-A1..A8 pipeline smoke (inspect artifacts)
+make -f Makefile.e2e e2e-ui-test       # Playwright UI acceptance
+make -f Makefile.e2e e2e-down          # remove harness (studio keeps running)
+```
+
+### Layer 3 — kind/minikube sandbox (real Kubernetes topology)
+
+The one thing compose can't do: real namespaces/pods/containers. A gProfiler
+agent **DaemonSet** on a real node reads the node's CRI socket and enumerates
+genuine workloads, so this layer proves discovery + scope resolution under
+Kubernetes. Tests: **`AT-K1..K5`** (agent registers as host; tenant namespaces,
+pods, and containers — incl. a 2-container pod — discovered from real CRI;
+host-scope start dispatches to the real agent). Full details:
+[`k8s-sandbox/K8S_SANDBOX.md`](k8s-sandbox/K8S_SANDBOX.md) (architecture +
+rationale: [`../docs/K8S_SANDBOX.md`](../docs/K8S_SANDBOX.md)).
+
+```bash
+cd deploy/k8s-sandbox
+
+# --- kind (default, recommended: lightweight, containerd-native) ---
+make -f Makefile.k8s k8s-all           # cluster + build + load + deploy + token
+make -f Makefile.k8s k8s-test          # AT-K1..K5 real-topology acceptance
+make -f Makefile.k8s k8s-status        # live inventory across all scopes
+make -f Makefile.k8s k8s-url           # -> https://localhost:30443 (admin/admin)
+make -f Makefile.k8s k8s-down-all      # delete the whole cluster
+```
+
+**Option: minikube instead of kind.** The same manifests, agent DaemonSet, and
+`AT-K1..K5` suite run unchanged on minikube — only cluster lifecycle, image
+loading, and the URL differ. Select it with `CLUSTER=minikube`, and use a distinct
+`CLUSTER_NAME` if a kind cluster is already running (kind binds host port `30443`;
+map minikube elsewhere, e.g. `--ports=30444:30443`, to avoid a collision):
+
+```bash
+cd deploy/k8s-sandbox
+make -f Makefile.k8s k8s-all  CLUSTER=minikube CLUSTER_NAME=gprofiler-mk
+make -f Makefile.k8s k8s-test CLUSTER=minikube CLUSTER_NAME=gprofiler-mk
+make -f Makefile.k8s k8s-url  CLUSTER=minikube CLUSTER_NAME=gprofiler-mk  # -> https://<minikube ip>:30443
+make -f Makefile.k8s k8s-down-all CLUSTER=minikube CLUSTER_NAME=gprofiler-mk
+```
+
+> **Caveat (why kind is the default).** With `--container-runtime=containerd`
+> minikube gives the same prod-like CRI path, but its **docker driver may fail to
+> boot on some hosts** (e.g. Docker 28 + cgroup v2 + newer kernels, where the node
+> container can't start systemd), while kind's `kindest/node` boots there fine. If
+> minikube won't start, use kind. See the "Challenge" section in
+> [`../docs/K8S_SANDBOX.md`](../docs/K8S_SANDBOX.md) for the full write-up.
 
 ## Optional: container/pod inventory
 
@@ -240,6 +315,11 @@ because the Docker socket isn't mounted (keeps it isolated from the host). To
 exercise namespace/pod/container scope tabs with a real agent, mount
 `/var/run/docker.sock:/var/run/docker.sock:ro` into `gprofiler-agent` — note this
 gives the agent visibility into all host containers.
+
+For **real** Kubernetes namespace/pod/container/process inventory (not the Docker
+socket workaround), use **Layer 3** — the kind/minikube sandbox — which runs an
+agent DaemonSet against a real node's CRI. See
+[The three-layer test harness](#the-three-layer-test-harness).
 
 ## Notes
 

--- a/deploy/k8s-sandbox/Makefile.k8s
+++ b/deploy/k8s-sandbox/Makefile.k8s
@@ -8,6 +8,7 @@
 # One-shot:
 #   make -f Makefile.k8s k8s-all          # cluster + build + load + deploy + token
 #   make -f Makefile.k8s k8s-test         # run AT-K1..K5 real-topology acceptance
+#   make -f Makefile.k8s spark-demo       # Spark-on-k8s + per-thread flamegraph
 #   make -f Makefile.k8s k8s-down-all     # delete the whole cluster
 #
 # Granular targets are listed in `make -f Makefile.k8s help`.
@@ -230,3 +231,62 @@ ifeq ($(CLUSTER),kind)
 else
 	minikube delete -p $(CLUSTER_NAME)
 endif
+
+# --------------------------------------------------------------------------- #
+# Spark-on-Kubernetes demo (spark/): a driver + 6 executor JVM pods deliberately
+# oversubscribed to be very busy, profiled PER JVM THREAD by the agent (which runs
+# with --java-async-profiler-args=threads). This is the workload that shows real
+# Spark executor task threads in a gProfiler flamegraph.
+# --------------------------------------------------------------------------- #
+SPARK_DIR             := spark
+SPARK_NS              := spark
+SPARK_IMAGE           := spark-cpu-job:sandbox
+SPARK_PROFILE_SECONDS ?= 90
+
+.PHONY: spark-build spark-load spark-submit spark-status spark-profile spark-demo spark-clean
+
+## spark-build     : build the Spark demo image (job baked into apache/spark)
+spark-build:
+	docker build -t $(SPARK_IMAGE) $(SPARK_DIR)
+
+## spark-load      : load the Spark image into the cluster (CLUSTER=kind|minikube)
+spark-load:
+	@if [ "$(CLUSTER)" = "kind" ]; then \
+	  kind load docker-image $(SPARK_IMAGE) --name $(CLUSTER_NAME); \
+	else \
+	  minikube image load $(SPARK_IMAGE) -p $(CLUSTER_NAME); \
+	fi
+
+## spark-submit    : RBAC + submit (spark-submit cluster mode -> driver + executors)
+spark-submit:
+	kubectl apply -f $(SPARK_DIR)/00-rbac.yaml
+	-kubectl -n $(SPARK_NS) delete job spark-submit --ignore-not-found --now
+	-kubectl -n $(SPARK_NS) delete pod spark-cpu-driver --ignore-not-found --now
+	kubectl apply -f $(SPARK_DIR)/10-submit-job.yaml
+	@echo ">> submitted. Driver + 6 executor pods appear in ns/$(SPARK_NS) within ~30-40s."
+
+## spark-status    : show the Spark driver + executor pods
+spark-status:
+	kubectl -n $(SPARK_NS) get pods -o wide
+
+## spark-profile   : host-scope profile while Spark runs (SPARK_PROFILE_SECONDS=90)
+spark-profile:
+	@host=$(call resolve_host); echo ">> profiling host=$$host for $(SPARK_PROFILE_SECONDS)s"; \
+	 req=$$(python3 -c "import json;print(json.dumps({'service_name':'$(SERVICE)','request_type':'start','continuous':False,'duration':$(SPARK_PROFILE_SECONDS),'frequency':11,'profiling_mode':'cpu','target_scope':'host','target_hosts':{'$$host':[]},'target_entities':[{'service_name':'$(SERVICE)','hostname':'$$host'}],'additional_args':{}}))"); \
+	 $(KUBECTL) run rq-$$RANDOM --image=curlimages/curl:8.7.1 --restart=Never -i --rm --quiet --command -- \
+	   curl -s -X POST "http://webapp/api/metrics/profile_request" -H "Content-Type: application/json" -d "$$req"
+
+## spark-demo      : build + load + submit + profile + list flamegraph (one-shot)
+spark-demo: spark-build spark-load spark-submit
+	@echo ">> letting executors schedule and get busy (~45s)..."; sleep 45
+	@$(MAKE) -f Makefile.k8s spark-status
+	@$(MAKE) -f Makefile.k8s spark-profile
+	@echo ">> waiting for the profile to run + upload..."; sleep $$(( $(SPARK_PROFILE_SECONDS) + 45 ))
+	@$(MAKE) -f Makefile.k8s k8s-flamegraph
+	@echo ">> done: the newest *_adhoc_flamegraph.html above is the Spark per-thread profile."
+
+## spark-clean     : remove the Spark job/driver + RBAC (deletes the spark namespace)
+spark-clean:
+	-kubectl -n $(SPARK_NS) delete job spark-submit --ignore-not-found
+	-kubectl -n $(SPARK_NS) delete pod spark-cpu-driver --ignore-not-found
+	-kubectl delete -f $(SPARK_DIR)/00-rbac.yaml --ignore-not-found

--- a/deploy/k8s-sandbox/Makefile.k8s
+++ b/deploy/k8s-sandbox/Makefile.k8s
@@ -8,7 +8,8 @@
 # One-shot:
 #   make -f Makefile.k8s k8s-all          # cluster + build + load + deploy + token
 #   make -f Makefile.k8s k8s-test         # run AT-K1..K5 real-topology acceptance
-#   make -f Makefile.k8s spark-demo       # Spark-on-k8s + per-thread flamegraph
+#   make -f Makefile.k8s spark-demo       # one Spark app + per-thread flamegraph
+#   make -f Makefile.k8s spark-multi-demo # several distinct Spark apps (relative weight)
 #   make -f Makefile.k8s k8s-down-all     # delete the whole cluster
 #
 # Granular targets are listed in `make -f Makefile.k8s help`.
@@ -242,8 +243,12 @@ SPARK_DIR             := spark
 SPARK_NS              := spark
 SPARK_IMAGE           := spark-cpu-job:sandbox
 SPARK_PROFILE_SECONDS ?= 90
+# Distinct workloads to run side by side (each becomes its own appid in gProfiler).
+SPARK_MODES           ?= agg join regex pyudf
+SPARK_MULTI_SECONDS   ?= 300
 
-.PHONY: spark-build spark-load spark-submit spark-status spark-profile spark-demo spark-clean
+.PHONY: spark-build spark-load spark-submit spark-status spark-profile spark-demo \
+        spark-multi spark-multi-demo spark-clean
 
 ## spark-build     : build the Spark demo image (job baked into apache/spark)
 spark-build:
@@ -285,8 +290,36 @@ spark-demo: spark-build spark-load spark-submit
 	@$(MAKE) -f Makefile.k8s k8s-flamegraph
 	@echo ">> done: the newest *_adhoc_flamegraph.html above is the Spark per-thread profile."
 
-## spark-clean     : remove the Spark job/driver + RBAC (deletes the spark namespace)
+## spark-multi     : submit SEVERAL distinct apps at once (SPARK_MODES="agg join regex pyudf")
+# Each mode hits a different hot path and carries its own app name, so gProfiler
+# shows them under separate appids -> you can compare RELATIVE weight across apps
+# instead of staring at four identical per-thread flamegraphs.
+spark-multi: spark-build spark-load
+	kubectl apply -f $(SPARK_DIR)/00-rbac.yaml
+	@for m in $(SPARK_MODES); do \
+	  name="spark-$$m"; \
+	  echo ">> submitting workload=$$m app=$$name"; \
+	  kubectl -n $(SPARK_NS) delete job spark-submit-$$m --ignore-not-found --now >/dev/null 2>&1; \
+	  kubectl -n $(SPARK_NS) delete pod spark-$$m-driver --ignore-not-found --now >/dev/null 2>&1; \
+	  sed -e "s/__SUFFIX__/$$m/g" -e "s/__MODE__/$$m/g" \
+	      -e "s/__APPNAME__/$$name/g" -e "s/__SECONDS__/$(SPARK_MULTI_SECONDS)/g" \
+	      $(SPARK_DIR)/11-submit-workload.yaml | kubectl apply -f - ; \
+	done
+	@echo ">> submitted modes: $(SPARK_MODES). Drivers + executors appear in ns/$(SPARK_NS) within ~40s."
+
+## spark-multi-demo: build+load+submit N apps + profile + list flamegraph (one-shot)
+spark-multi-demo: spark-multi
+	@echo ">> letting all apps schedule and get busy (~60s)..."; sleep 60
+	@$(MAKE) -f Makefile.k8s spark-status
+	@$(MAKE) -f Makefile.k8s spark-profile
+	@echo ">> waiting for the profile to run + upload..."; sleep $$(( $(SPARK_PROFILE_SECONDS) + 45 ))
+	@$(MAKE) -f Makefile.k8s k8s-flamegraph
+	@echo ">> done. In the gProfiler UI, filter by appid (java: spark-agg / spark-join /"
+	@echo "   spark-regex / spark-python-udf) to compare each app's relative weight."
+
+## spark-clean     : remove all Spark jobs/drivers + RBAC (deletes the spark namespace)
 spark-clean:
+	-kubectl -n $(SPARK_NS) delete job -l app=spark-submit --ignore-not-found
 	-kubectl -n $(SPARK_NS) delete job spark-submit --ignore-not-found
 	-kubectl -n $(SPARK_NS) delete pod spark-cpu-driver --ignore-not-found
 	-kubectl delete -f $(SPARK_DIR)/00-rbac.yaml --ignore-not-found

--- a/deploy/k8s-sandbox/Makefile.k8s
+++ b/deploy/k8s-sandbox/Makefile.k8s
@@ -246,6 +246,9 @@ SPARK_PROFILE_SECONDS ?= 90
 # Distinct workloads to run side by side (each becomes its own appid in gProfiler).
 SPARK_MODES           ?= agg join regex pyudf
 SPARK_MULTI_SECONDS   ?= 300
+# Partitions per app => task count => number of per-thread columns. Lower it
+# (e.g. SPARK_PARTITIONS=6) for a less crowded per-thread flamegraph.
+SPARK_PARTITIONS      ?= 24
 
 .PHONY: spark-build spark-load spark-submit spark-status spark-profile spark-demo \
         spark-multi spark-multi-demo spark-clean
@@ -303,6 +306,7 @@ spark-multi: spark-build spark-load
 	  kubectl -n $(SPARK_NS) delete pod spark-$$m-driver --ignore-not-found --now >/dev/null 2>&1; \
 	  sed -e "s/__SUFFIX__/$$m/g" -e "s/__MODE__/$$m/g" \
 	      -e "s/__APPNAME__/$$name/g" -e "s/__SECONDS__/$(SPARK_MULTI_SECONDS)/g" \
+	      -e "s/__PARTS__/$(SPARK_PARTITIONS)/g" \
 	      $(SPARK_DIR)/11-submit-workload.yaml | kubectl apply -f - ; \
 	done
 	@echo ">> submitted modes: $(SPARK_MODES). Drivers + executors appear in ns/$(SPARK_NS) within ~40s."

--- a/deploy/k8s-sandbox/manifests/50-agent-daemonset.yaml
+++ b/deploy/k8s-sandbox/manifests/50-agent-daemonset.yaml
@@ -48,6 +48,14 @@ spec:
             - --output-dir=/tmp/gprofiler_output
             - --dont-send-logs
             - --disable-pidns-check
+            # Per-thread Java profiling: appends ',threads' to async-profiler so
+            # each sample is split by (and prefixed with) its JVM thread name
+            # (e.g. "Executor task launch worker-0"). This is the async-profiler
+            # "thread renaming in samples" capability surfaced via gProfiler.
+            - --java-async-profiler-args=threads
+            # Tag Spark executor samples with the Spark application name in the
+            # appid, so different Spark apps are distinguishable in the data.
+            - --java-collect-spark-app-name-as-appid
           env:
             - name: GPROFILER_IN_CONTAINER
               value: "1"
@@ -65,7 +73,9 @@ spec:
               valueFrom: { fieldRef: { fieldPath: spec.nodeName } }
           resources:
             requests: { cpu: 100m, memory: 128Mi }
-            limits: { cpu: "1", memory: 512Mi }
+            # bumped: per-thread collapsed output + a busy 6-executor Spark app
+            # produces a much larger profile to hold/merge.
+            limits: { cpu: "2", memory: 1Gi }
       # Tolerate control-plane taints so the DaemonSet also lands on a
       # single-node kind/minikube cluster's control-plane node.
       tolerations:

--- a/deploy/k8s-sandbox/spark/00-rbac.yaml
+++ b/deploy/k8s-sandbox/spark/00-rbac.yaml
@@ -1,0 +1,35 @@
+# Namespace + service account the Spark driver uses to create executor pods.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: spark
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spark
+  namespace: spark
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: spark-role
+  namespace: spark
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "services", "configmaps", "persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: spark-role-binding
+  namespace: spark
+subjects:
+  - kind: ServiceAccount
+    name: spark
+    namespace: spark
+roleRef:
+  kind: Role
+  name: spark-role
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/k8s-sandbox/spark/10-submit-job.yaml
+++ b/deploy/k8s-sandbox/spark/10-submit-job.yaml
@@ -1,0 +1,67 @@
+# A one-shot pod that runs spark-submit in k8s "cluster" deploy mode. spark-submit
+# creates the driver pod, which in turn creates the executor pods. Cluster mode is
+# used because Spark then wires driver<->executor networking automatically (it
+# creates a headless service for the driver), avoiding client-mode host/port setup.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: spark-submit
+  namespace: spark
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app: spark-submit
+    spec:
+      serviceAccountName: spark
+      restartPolicy: Never
+      containers:
+        - name: submit
+          image: spark-cpu-job:sandbox
+          imagePullPolicy: IfNotPresent
+          command:
+            - /opt/spark/bin/spark-submit
+            - --master
+            - k8s://https://kubernetes.default.svc:443
+            - --deploy-mode
+            - cluster
+            - --name
+            - spark-cpu
+            - --conf
+            - spark.kubernetes.namespace=spark
+            - --conf
+            - spark.kubernetes.authenticate.driver.serviceAccountName=spark
+            - --conf
+            - spark.kubernetes.authenticate.submission.caCertFile=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            - --conf
+            - spark.kubernetes.authenticate.submission.oauthTokenFile=/var/run/secrets/kubernetes.io/serviceaccount/token
+            - --conf
+            - spark.kubernetes.container.image=spark-cpu-job:sandbox
+            - --conf
+            - spark.kubernetes.container.image.pullPolicy=IfNotPresent
+            - --conf
+            - spark.kubernetes.driver.pod.name=spark-cpu-driver
+            - --conf
+            - spark.kubernetes.submission.waitAppCompletion=true
+            - --conf
+            - spark.executor.instances=6
+            - --conf
+            - spark.executor.cores=4
+            # Decouple task parallelism from the k8s CPU *request* so all 6 executor
+            # pods schedule on a 16-core node (6x4=24 threads > 16 cores => oversubscribed
+            # and deliberately very busy), instead of requesting 4 cores each and leaving
+            # half the executors Pending.
+            - --conf
+            - spark.kubernetes.executor.request.cores=1
+            - --conf
+            - spark.executor.memory=1g
+            - --conf
+            - spark.driver.cores=1
+            - --conf
+            - spark.driver.memory=1g
+            # keep executors around briefly after finish so they're easy to inspect
+            - --conf
+            - spark.kubernetes.executor.deleteOnTermination=true
+            - local:///opt/spark_cpu_job.py
+            - "600"

--- a/deploy/k8s-sandbox/spark/11-submit-workload.yaml
+++ b/deploy/k8s-sandbox/spark/11-submit-workload.yaml
@@ -1,0 +1,72 @@
+# Templated spark-submit Job for ONE workload mode. The Makefile `spark-multi`
+# target sed-substitutes the __PLACEHOLDERS__ and applies one copy per mode, so
+# several distinct Spark apps run side by side. Each app is smaller than the
+# single-app demo (2 executors x 2 cores) so 3-4 apps fit on the 16-core node.
+#
+# Placeholders: __SUFFIX__ (mode), __MODE__, __APPNAME__, __SECONDS__
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: spark-submit-__SUFFIX__
+  namespace: spark
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app: spark-submit
+        workload: __SUFFIX__
+    spec:
+      serviceAccountName: spark
+      restartPolicy: Never
+      containers:
+        - name: submit
+          image: spark-cpu-job:sandbox
+          imagePullPolicy: IfNotPresent
+          command:
+            - /opt/spark/bin/spark-submit
+            - --master
+            - k8s://https://kubernetes.default.svc:443
+            - --deploy-mode
+            - cluster
+            - --name
+            - __APPNAME__
+            - --conf
+            - spark.kubernetes.namespace=spark
+            - --conf
+            - spark.kubernetes.authenticate.driver.serviceAccountName=spark
+            - --conf
+            - spark.kubernetes.authenticate.submission.caCertFile=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            - --conf
+            - spark.kubernetes.authenticate.submission.oauthTokenFile=/var/run/secrets/kubernetes.io/serviceaccount/token
+            - --conf
+            - spark.kubernetes.container.image=spark-cpu-job:sandbox
+            - --conf
+            - spark.kubernetes.container.image.pullPolicy=IfNotPresent
+            - --conf
+            - spark.kubernetes.driver.pod.name=spark-__SUFFIX__-driver
+            # Label the executor pods so `kubectl get pods -l workload=<mode>` groups them.
+            - --conf
+            - spark.kubernetes.executor.label.workload=__SUFFIX__
+            - --conf
+            - spark.kubernetes.submission.waitAppCompletion=true
+            # Per-app footprint kept small so several apps schedule concurrently:
+            # 2 executors x 2 cores = 4 task threads/app, but request only 1 core each.
+            - --conf
+            - spark.executor.instances=2
+            - --conf
+            - spark.executor.cores=2
+            - --conf
+            - spark.kubernetes.executor.request.cores=1
+            - --conf
+            - spark.executor.memory=1g
+            - --conf
+            - spark.driver.cores=1
+            - --conf
+            - spark.driver.memory=1g
+            - --conf
+            - spark.kubernetes.executor.deleteOnTermination=true
+            - local:///opt/spark_workloads.py
+            - __MODE__
+            - "__SECONDS__"
+            - __APPNAME__

--- a/deploy/k8s-sandbox/spark/11-submit-workload.yaml
+++ b/deploy/k8s-sandbox/spark/11-submit-workload.yaml
@@ -70,3 +70,4 @@ spec:
             - __MODE__
             - "__SECONDS__"
             - __APPNAME__
+            - "__PARTS__"

--- a/deploy/k8s-sandbox/spark/Dockerfile
+++ b/deploy/k8s-sandbox/spark/Dockerfile
@@ -1,0 +1,5 @@
+# Thin layer over the official Spark image that bakes in the CPU-burn job so the
+# driver/executor pods can reference it via local:// (no file upload needed).
+FROM apache/spark:3.5.1
+
+COPY spark_cpu_job.py /opt/spark_cpu_job.py

--- a/deploy/k8s-sandbox/spark/Dockerfile
+++ b/deploy/k8s-sandbox/spark/Dockerfile
@@ -3,3 +3,4 @@
 FROM apache/spark:3.5.1
 
 COPY spark_cpu_job.py /opt/spark_cpu_job.py
+COPY spark_workloads.py /opt/spark_workloads.py

--- a/deploy/k8s-sandbox/spark/README.md
+++ b/deploy/k8s-sandbox/spark/README.md
@@ -1,0 +1,71 @@
+# Spark-on-Kubernetes profiling demos
+
+Two demos that run Spark as real k8s pods so the gProfiler agent DaemonSet
+profiles the executor JVMs per thread:
+
+| demo | what runs | use it to see |
+|------|-----------|---------------|
+| **single** (`spark-demo`) | one CPU-burn app: 6 executors x 4 task threads | per-thread Java flamegraph of one busy Spark app |
+| **multi** (`spark-multi-demo`) | 4 *different* apps side by side | **relative weight** of different workloads |
+
+## Why "multi"? (relative weight)
+
+When every executor runs the same kernel, all the per-thread flamegraphs look
+alike. `spark-multi` submits four apps that each hammer a different hot path, so
+the profile shows visibly different stacks and lets you compare where CPU goes:
+
+| mode | app name | dominant frames |
+|------|----------|-----------------|
+| `agg`   | `spark-agg`   | `WholeStageCodegen` + transcendental math (`sin/cos/sqrt/log`) |
+| `join`  | `spark-join`  | sort-merge join: `UnsafeExternalSorter`, `ShuffleWriter`, `Sorter` |
+| `regex` | `spark-regex` | `java.util.regex` (`Pattern`/`Matcher`) + codegen |
+| `pyudf` | `spark-pyudf` | Python UDF: JVM `PythonRunner` + Python worker CPU (`appid: pyspark`) |
+
+Example from one 120s host profile (8 executor JVMs, 16-core node):
+
+```
+spark-pyudf   43.9% of Spark CPU     (Python worker dominated)
+spark-regex   31.6%
+spark-join    14.0%
+spark-agg     10.4%
+```
+
+## Running
+
+```bash
+cd deploy/k8s-sandbox
+
+make -f Makefile.k8s spark-demo         # single app, one-shot
+make -f Makefile.k8s spark-multi-demo   # 4 distinct apps, one-shot
+
+# granular
+make -f Makefile.k8s spark-multi SPARK_MODES="agg join regex pyudf" SPARK_MULTI_SECONDS=1200
+make -f Makefile.k8s spark-status
+make -f Makefile.k8s spark-profile SPARK_PROFILE_SECONDS=120
+make -f Makefile.k8s spark-clean
+```
+
+## Files
+
+- `spark_cpu_job.py` — single-app CPU burn (used by `spark-demo`).
+- `spark_workloads.py` — multi-mode workloads (used by `spark-multi`), dispatched by `<mode>` arg.
+- `Dockerfile` — thin layer over `apache/spark:3.5.1` baking both scripts in.
+- `00-rbac.yaml` — `spark` namespace + ServiceAccount/Role so the driver can create executor pods.
+- `10-submit-job.yaml` — single-app `spark-submit` Job (cluster mode).
+- `11-submit-workload.yaml` — templated per-mode Job (`__SUFFIX__/__MODE__/__APPNAME__/__SECONDS__`).
+
+## Gotchas (learned the hard way)
+
+1. **Profile while the apps are running.** The Spark Jobs exit after
+   `SPARK_MULTI_SECONDS`. If they finish before the profile window, async-profiler
+   has no JVMs to attach to and you get a Python-only capture. `spark-*-demo`
+   size the run window to cover profiling; if you drive it manually, submit with a
+   long duration and profile promptly (`spark-status` should show executors
+   `Running`).
+2. **appid does not split Spark apps on k8s 3.5.** All executors report
+   `appid: java: org.apache.spark...KubernetesExecutorBackend`, so
+   `--java-collect-spark-app-name-as-appid` won't separate them in the UI.
+   gProfiler's Spark detector (`_JavaSparkApplicationIdentifier`) matches
+   `org.apache.spark.executor` in argv, which the k8s executor backend main class
+   no longer contains. Group by the executor **pod** (its name is a frame in every
+   sample) or the `workload=<mode>` pod label instead.

--- a/deploy/k8s-sandbox/spark/README.md
+++ b/deploy/k8s-sandbox/spark/README.md
@@ -20,6 +20,16 @@ the profile shows visibly different stacks and lets you compare where CPU goes:
 | `join`  | `spark-join`  | sort-merge join: `UnsafeExternalSorter`, `ShuffleWriter`, `Sorter` |
 | `regex` | `spark-regex` | `java.util.regex` (`Pattern`/`Matcher`) + codegen |
 | `pyudf` | `spark-pyudf` | Python UDF: JVM `PythonRunner` + Python worker CPU (`appid: pyspark`) |
+| `skew`  | `spark-skew`  | data skew: ONE task-launch-worker thread dominates, the rest finish fast |
+
+`agg/join/regex/pyudf` make the *apps* differ. `skew` makes the *threads within one
+app* differ -- ~98% of rows land on one partition so a single "Executor task launch
+worker" thread is far wider than its peers (vs the uniform widths you get when every
+task does equal work):
+
+```bash
+make -f Makefile.k8s spark-multi SPARK_MODES="skew" SPARK_MULTI_SECONDS=1200
+```
 
 Example from one 120s host profile (8 executor JVMs, 16-core node):
 
@@ -44,6 +54,33 @@ make -f Makefile.k8s spark-status
 make -f Makefile.k8s spark-profile SPARK_PROFILE_SECONDS=120
 make -f Makefile.k8s spark-clean
 ```
+
+## Reading the per-thread flamegraph
+
+The agent runs async-profiler in `threads` mode, so each stack is prefixed with its
+JVM thread name. Spark task threads look like:
+
+```
+Executor task launch worker for task 1.0 in stage 165.0 (TID 1376) tid=334
+                                    │    │          │            │        └ OS thread id
+                                    │    │          │            └ Spark task id (unique within the app)
+                                    │    │          └ stage id (within the app)
+                                    └────┴ taskId.attempt
+```
+
+That identifies the task/stage/thread **within one JVM**, but NOT which app -- stage
+and TID numbering restart per app. The app is a *separate* frame in every sample: the
+executor pod, e.g. `k8s_spark_spark-<mode>-<execid>-exec-N_spark_...`. To attribute a
+thread to an app:
+
+- Switch the flamegraph's top grouping from `appid` to **container / process name**
+  (or filter by pod). Then each thread rolls up under its `spark-<mode>` pod.
+- Or, in the raw collapsed `.gz`, group by the `spark-<mode>-...-exec-N` frame.
+
+Why they all share one `appid: java: org.apache.spark...KubernetesExecutorBackend`:
+see gotcha #2 below. If you want the appid dropdown itself to separate the apps,
+patch the agent's `_JavaSparkApplicationIdentifier` to also match the k8s executor
+backend class (it already reads `spark.app.name`), then `make agent-build` + rollout.
 
 ## Files
 

--- a/deploy/k8s-sandbox/spark/README.md
+++ b/deploy/k8s-sandbox/spark/README.md
@@ -25,11 +25,29 @@ the profile shows visibly different stacks and lets you compare where CPU goes:
 `agg/join/regex/pyudf` make the *apps* differ. `skew` makes the *threads within one
 app* differ -- ~98% of rows land on one partition so a single "Executor task launch
 worker" thread is far wider than its peers (vs the uniform widths you get when every
-task does equal work):
+task does equal work).
+
+**Preferred readable demo** (one app, few partitions, short profile):
 
 ```bash
-make -f Makefile.k8s spark-multi SPARK_MODES="skew" SPARK_MULTI_SECONDS=1200
+# 4 partitions keep the per-thread forest small; skew makes one task ~3-4x wider.
+make -f Makefile.k8s spark-multi \
+  SPARK_MODES="skew" SPARK_PARTITIONS=4 SPARK_MULTI_SECONDS=500
+make -f Makefile.k8s spark-profile SPARK_PROFILE_SECONDS=30
 ```
+
+Measured on the sandbox (one 30s profile while skew was busy):
+
+```
+task 1:  53.7%   ################################   <- hot partition
+task 3:  18.5%   ###########
+task 2:  15.3%   #########
+task 0:  12.5%   #######
+```
+
+`SPARK_PARTITIONS` (default 24) controls how many task-thread columns appear under
+async-profiler's per-sample rename. Lower it when the flamegraph looks like a
+forest of equal slivers.
 
 Example from one 120s host profile (8 executor JVMs, 16-core node):
 
@@ -89,7 +107,7 @@ backend class (it already reads `spark.app.name`), then `make agent-build` + rol
 - `Dockerfile` — thin layer over `apache/spark:3.5.1` baking both scripts in.
 - `00-rbac.yaml` — `spark` namespace + ServiceAccount/Role so the driver can create executor pods.
 - `10-submit-job.yaml` — single-app `spark-submit` Job (cluster mode).
-- `11-submit-workload.yaml` — templated per-mode Job (`__SUFFIX__/__MODE__/__APPNAME__/__SECONDS__`).
+- `11-submit-workload.yaml` — templated per-mode Job (`__SUFFIX__/__MODE__/__APPNAME__/__SECONDS__/__PARTS__`).
 
 ## Gotchas (learned the hard way)
 
@@ -106,3 +124,11 @@ backend class (it already reads `spark.app.name`), then `make agent-build` + rol
    `org.apache.spark.executor` in argv, which the k8s executor backend main class
    no longer contains. Group by the executor **pod** (its name is a frame in every
    sample) or the `workload=<mode>` pod label instead.
+3. **Uniform workloads + per-thread naming = a forest.** Spark renames the
+   executor task thread for *every* task (`... for task X in stage Y [TID N]`),
+   so a busy uniform app fans into one thin column per task. Use `skew` (or
+   lower `SPARK_PARTITIONS`) when you want a readable per-thread view.
+4. **Wedged ad-hoc agent.** If `spark-profile` returns success but no new `.gz`
+   lands in S3 / the UI stays stale, the agent may be stuck re-skipping a prior
+   command (`Command ID ... already received, skipping`). Restart it:
+   `kubectl -n perf-studio rollout restart ds/gprofiler-agent`.

--- a/deploy/k8s-sandbox/spark/spark_cpu_job.py
+++ b/deploy/k8s-sandbox/spark/spark_cpu_job.py
@@ -1,0 +1,44 @@
+"""CPU-heavy Spark job whose hot path stays inside the executor JVMs.
+
+It uses only Catalyst/DataFrame built-ins (no Python UDFs), so all the arithmetic
+runs as whole-stage-codegen'd bytecode on the executor JVM task threads -- exactly
+the Java threads we want gProfiler to profile. The Python driver just orchestrates.
+
+Arg 1 (optional): how many seconds to keep the cluster busy (default 300).
+"""
+import sys
+import time
+
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import col, sqrt, sin, cos, log, expr
+
+RUN_SECONDS = int(sys.argv[1]) if len(sys.argv) > 1 else 300
+# 48 partitions keeps all executor task threads (6 execs x 4 cores = 24 slots)
+# saturated with a backlog, so every JVM worker thread stays busy.
+PARTITIONS = 48
+ROWS = 40_000_000
+
+spark = (
+    SparkSession.builder.appName("spark-cpu-burn")
+    .getOrCreate()
+)
+print(f">> spark-cpu-burn starting: run_seconds={RUN_SECONDS} "
+      f"partitions={PARTITIONS} rows={ROWS}", flush=True)
+
+deadline = time.time() + RUN_SECONDS
+iteration = 0
+while time.time() < deadline:
+    df = spark.range(0, ROWS, numPartitions=PARTITIONS)
+    # Stack several transcendental ops so each row costs real CPU in the JVM.
+    for _ in range(8):
+        df = (
+            df.withColumn("v", sqrt(col("id") + 1.0))
+              .withColumn("v", sin(col("v")) * cos(col("v")) + log(col("v") + 2.0))
+              .withColumn("id", (col("id") + 1) % ROWS)
+        )
+    total = df.agg(expr("sum(v) as s")).collect()[0]["s"]
+    iteration += 1
+    print(f">> iteration {iteration} done sum={total}", flush=True)
+
+print(">> spark-cpu-burn finished", flush=True)
+spark.stop()

--- a/deploy/k8s-sandbox/spark/spark_workloads.py
+++ b/deploy/k8s-sandbox/spark/spark_workloads.py
@@ -20,6 +20,8 @@ Each mode stresses a different Catalyst/JVM path:
   join   -> shuffle + sort-merge join (ExternalSorter, ShuffleWriter, SMJ)
   regex  -> string/regex parsing (java.util.regex, UTF8String)
   pyudf  -> Python UDF round-trips (JVM PythonRunner + socket, Python worker CPU)
+  skew   -> deliberate data skew so ONE task thread dominates the flamegraph
+            (the others finish fast) -- use it to see unequal per-thread weight
 
 Usage: spark_workloads.py <mode> <run_seconds> [app_name]
 """
@@ -99,7 +101,27 @@ def run_pyudf():
     return df.agg(F.sum("v")).collect()[0][0]
 
 
-RUNNERS = {"agg": run_agg, "join": run_join, "regex": run_regex, "pyudf": run_pyudf}
+def run_skew():
+    """DELIBERATE DATA SKEW: ~98% of rows collapse onto a single partition key, so
+    after the repartition ONE downstream task gets almost all the rows and its
+    'Executor task launch worker' thread dominates the flamegraph while the other
+    task threads finish quickly. Use this to see one thread far wider than the rest
+    (vs the uniform-width threads you get when every task does equal work)."""
+    rows = 12_000_000
+    base = spark.range(0, rows, numPartitions=PARTITIONS)
+    # id % 50 != 0  -> key 0 (98% of rows); else a spread key. One hot partition.
+    keyed = base.withColumn("p", F.when(F.col("id") % 50 != 0, F.lit(0)).otherwise(F.col("id")))
+    skewed = keyed.repartition(PARTITIONS, "p")
+    # Heavy per-row math in the skewed stage so the hot task actually burns CPU.
+    for _ in range(6):
+        skewed = (skewed.withColumn("v", F.sqrt(F.col("id") + 1.0))
+                        .withColumn("v", F.sin(F.col("v")) * F.cos(F.col("v"))
+                                    + F.log(F.col("v") + 2.0)))
+    return skewed.agg(F.sum("v").alias("s")).collect()[0]["s"]
+
+
+RUNNERS = {"agg": run_agg, "join": run_join, "regex": run_regex,
+           "pyudf": run_pyudf, "skew": run_skew}
 runner = RUNNERS.get(MODE, run_agg)
 
 deadline = time.time() + RUN_SECONDS

--- a/deploy/k8s-sandbox/spark/spark_workloads.py
+++ b/deploy/k8s-sandbox/spark/spark_workloads.py
@@ -1,0 +1,113 @@
+"""Several DISTINCT CPU-heavy Spark workloads, each with its own Spark app name.
+
+Why this exists: when every executor runs the same kernel, the per-thread
+flamegraphs all look alike. Running a few *different* apps side by side gives
+gProfiler visibly different stacks and lets you compare RELATIVE weight across
+apps.
+
+How to tell the apps apart in the profile: each app's executor pods are named
+`spark-<mode>-<id>-exec-N` and that pod identity appears as a frame in every
+sample (k8s_spark_spark-<mode>-...-exec-N_spark_...), so you group/filter by
+workload there. NOTE: on Spark 3.5's k8s executors the built-in
+--java-collect-spark-app-name-as-appid does NOT split the apps -- they all share
+`appid: java: org.apache.spark...KubernetesExecutorBackend` (gProfiler's spark
+detector keys off `org.apache.spark.executor` in argv, which the k8s executor
+backend main class no longer matches). Group by the executor pod / the
+`workload=<mode>` label instead. See spark/README.md.
+
+Each mode stresses a different Catalyst/JVM path:
+  agg    -> whole-stage codegen + transcendental math (HashAggregate, codegen)
+  join   -> shuffle + sort-merge join (ExternalSorter, ShuffleWriter, SMJ)
+  regex  -> string/regex parsing (java.util.regex, UTF8String)
+  pyudf  -> Python UDF round-trips (JVM PythonRunner + socket, Python worker CPU)
+
+Usage: spark_workloads.py <mode> <run_seconds> [app_name]
+"""
+import math
+import sys
+import time
+
+from pyspark.sql import SparkSession
+from pyspark.sql import functions as F
+from pyspark.sql.types import DoubleType
+
+MODE = sys.argv[1] if len(sys.argv) > 1 else "agg"
+RUN_SECONDS = int(sys.argv[2]) if len(sys.argv) > 2 else 300
+APP_NAME = sys.argv[3] if len(sys.argv) > 3 else f"spark-{MODE}"
+
+PARTITIONS = 24
+
+spark = SparkSession.builder.appName(APP_NAME).getOrCreate()
+print(f">> {APP_NAME} starting: mode={MODE} run_seconds={RUN_SECONDS} "
+      f"partitions={PARTITIONS}", flush=True)
+
+
+def run_agg():
+    """Transcendental math folded into whole-stage codegen -> pure JVM CPU."""
+    rows = 20_000_000
+    df = spark.range(0, rows, numPartitions=PARTITIONS)
+    for _ in range(8):
+        df = (df.withColumn("v", F.sqrt(F.col("id") + 1.0))
+                .withColumn("v", F.sin(F.col("v")) * F.cos(F.col("v"))
+                            + F.log(F.col("v") + 2.0))
+                .withColumn("id", (F.col("id") + 1) % rows))
+    return df.agg(F.expr("sum(v) as s")).collect()[0]["s"]
+
+
+def run_join():
+    """1:1 sort-merge join across two big frames -> heavy shuffle + external sort."""
+    rows = 8_000_000
+    left = (spark.range(0, rows, numPartitions=PARTITIONS)
+            .withColumn("k", (F.col("id") * 2654435761) % rows)
+            .withColumnRenamed("id", "lid"))
+    right = (spark.range(0, rows, numPartitions=PARTITIONS)
+             .withColumn("k", (F.col("id") * 40503) % rows)
+             .withColumnRenamed("id", "rid"))
+    joined = left.join(right, on="k", how="inner")
+    return joined.agg(F.count(F.lit(1)).alias("c")).collect()[0]["c"]
+
+
+def run_regex():
+    """Regex extract/replace over synthetic strings -> java.util.regex hot path."""
+    rows = 8_000_000
+    base = spark.range(0, rows, numPartitions=PARTITIONS)
+    s = base.withColumn(
+        "s",
+        F.concat(F.lit("id-"), F.col("id").cast("string"),
+                 F.lit("-x9y8z7-"), (F.col("id") % 9973).cast("string")),
+    )
+    for _ in range(6):
+        s = (s.withColumn("d", F.regexp_extract(F.col("s"), r"id-(\d+)-", 1))
+               .withColumn("up", F.upper(F.col("s")))
+               .withColumn("rep", F.regexp_replace(F.col("s"), r"[0-9]", "#")))
+    return s.agg(F.sum(F.length(F.col("rep")))).collect()[0][0]
+
+
+def run_pyudf():
+    """Python UDF forces rows through Python workers -> distinct PythonRunner/
+    socket stacks in the JVM (plus CPU burned in the python worker processes)."""
+    rows = 1_500_000
+
+    @F.udf(DoubleType())
+    def churn(x):
+        v = float(x)
+        for _ in range(200):
+            v = math.sin(v) * math.cos(v) + math.sqrt(abs(v) + 1.0)
+        return v
+
+    df = spark.range(0, rows, numPartitions=PARTITIONS).withColumn("v", churn(F.col("id")))
+    return df.agg(F.sum("v")).collect()[0][0]
+
+
+RUNNERS = {"agg": run_agg, "join": run_join, "regex": run_regex, "pyudf": run_pyudf}
+runner = RUNNERS.get(MODE, run_agg)
+
+deadline = time.time() + RUN_SECONDS
+iteration = 0
+while time.time() < deadline:
+    result = runner()
+    iteration += 1
+    print(f">> {APP_NAME} iter {iteration} result={result}", flush=True)
+
+print(f">> {APP_NAME} finished", flush=True)
+spark.stop()

--- a/deploy/k8s-sandbox/spark/spark_workloads.py
+++ b/deploy/k8s-sandbox/spark/spark_workloads.py
@@ -36,8 +36,9 @@ from pyspark.sql.types import DoubleType
 MODE = sys.argv[1] if len(sys.argv) > 1 else "agg"
 RUN_SECONDS = int(sys.argv[2]) if len(sys.argv) > 2 else 300
 APP_NAME = sys.argv[3] if len(sys.argv) > 3 else f"spark-{MODE}"
-
-PARTITIONS = 24
+# Fewer partitions -> fewer tasks -> fewer per-thread columns in the flamegraph
+# (each task becomes its own thread-name frame under per-sample renaming).
+PARTITIONS = int(sys.argv[4]) if len(sys.argv) > 4 else 24
 
 spark = SparkSession.builder.appName(APP_NAME).getOrCreate()
 print(f">> {APP_NAME} starting: mode={MODE} run_seconds={RUN_SECONDS} "

--- a/docs/K8S_SANDBOX.md
+++ b/docs/K8S_SANDBOX.md
@@ -85,6 +85,32 @@ minikube is **not wrong** — with `--container-runtime=containerd` it produces 
 same containerd CRI topology and the manifests/tests are identical. It's just
 heavier and has more environment-specific setup.
 
+### Isolation model: VM drivers vs container drivers (and why no VM here)
+
+A common assumption is "minikube = an isolated VM." That was minikube's original
+design, but today its isolation depends on the **driver**:
+
+- **VM drivers** (`kvm2`, `virtualbox`, `hyperkit`, `hyper-v`, `qemu`) boot a real
+  virtual machine with its **own kernel** — the strongest isolation, and
+  minikube's genuine edge over kind *when a hypervisor is available*.
+- **Container drivers** (`docker`, `podman`) run the node as a **container sharing
+  the host kernel** — the same model as kind (which is *always* a container).
+- **`none`** runs the kubelet directly on the host (no isolation).
+
+Either way the *cluster* is hermetic and disposable; what differs is whether the
+boundary is a separate kernel (VM) or a shared-kernel container.
+
+**Why this host only offers the container driver.** The build host is a standard
+(non-`.metal`) AWS EC2 instance — itself a guest VM that does **not expose nested
+virtualization**: there is no `/dev/kvm`, `/proc/cpuinfo` shows zero `vmx`/`svm`
+flags, and `systemd-detect-virt` reports `amazon`. A VM driver needs hardware
+virtualization (VT-x/AMD-V) passed through to the guest, so `kvm2`/`virtualbox`
+cannot run — only the `docker` (container) driver is viable. That is why minikube
+here has the *same* shared-kernel boundary as kind and hits the same
+systemd-in-container problem described in the Challenge below. To get a true
+minikube VM on AWS you need a **bare-metal instance type** (e.g. `*.metal`), which
+exposes the CPU virtualization extensions to the guest.
+
 ## Challenge: minikube's docker driver won't boot on this host
 
 `CLUSTER=minikube` is fully wired into `Makefile.k8s`, but when validated on the


### PR DESCRIPTION
## Summary

Follow-up to #84. Adds a **Spark-on-Kubernetes** workload to the sandbox and the gProfiler settings to profile it **per JVM thread**, plus docs that tie the whole test setup together as an explicit three-layer harness.

## What's included

- **`deploy/k8s-sandbox/spark/`** — a Spark app submitted in **k8s cluster mode** (driver + N executor pods, native k8s scheduler creating executor pods):
  - `spark_cpu_job.py` — CPU-burn job that stays entirely in the JVM (DataFrame/SQL built-ins, **no Python UDFs**), so executor **task threads** are the hot path gProfiler profiles.
  - `Dockerfile` — thin layer over `apache/spark:3.5.1` baking in the job (`local://` submit; the base image is JRE-only, so no compiled jar path).
  - `00-rbac.yaml` — `spark` namespace + ServiceAccount + Role/RoleBinding (driver needs to create executor pods).
  - `10-submit-job.yaml` — spark-submit Job; decouples task parallelism from the k8s CPU *request* so all executor pods schedule (deliberately oversubscribed = very busy).
- **`manifests/50-agent-daemonset.yaml`** — enable **per-thread Java profiling** via `--java-async-profiler-args=threads` (async-profiler splits/labels each sample by JVM thread name, e.g. `Executor task launch worker for task 21.0 in stage 492.0 (TID 8057)`), plus `--java-collect-spark-app-name-as-appid`; bump agent limits for the larger per-thread output.
- **`docs/K8S_SANDBOX.md`** — add an **isolation model** note (VM vs container drivers; why a non-`.metal` EC2 guest exposes no nested virtualization → only the container driver is viable) next to the existing minikube Challenge write-up.
- **`deploy/E2E_HARNESS.md`** — reframe as an explicit **three-layer** harness (fast unit → compose → kind/minikube sandbox) with how to invoke each layer and the minikube options/caveats.

## Verified

Ran on the local kind sandbox: 6 executor pods (24 task threads, node load ~26 on 16 cores), profiled during the busy window. The captured profile shows **51% Spark/Scala samples**, even attribution across all 6 executor pods, and **per-thread split** — real thread names for task workers, `C2/C1 CompilerThre`, `VM Thread`, etc. Whole-stage-codegen frames (`GeneratedIteratorForCodegenStage1.project_doConsume_0`) dominate, as expected.

## Test plan

- `cd deploy/k8s-sandbox && make -f Makefile.k8s k8s-all` (sandbox up with per-thread agent)
- `kubectl apply -f spark/00-rbac.yaml -f spark/10-submit-job.yaml` (after `kind load docker-image spark-cpu-job:sandbox`)
- Trigger a host-scope profile during the run; confirm per-thread Spark frames in the flamegraph artifact (LocalStack S3)

Made with [Cursor](https://cursor.com)